### PR TITLE
Fix wrong URL in curl examples

### DIFF
--- a/bing-docs/bing-news-search/how-to/search-for-news.md
+++ b/bing-docs/bing-news-search/how-to/search-for-news.md
@@ -10,7 +10,7 @@ ms.service: bing-search-services
 ms.subservice: bing-news-search
 ms.topic: conceptual
 ms.date: 11/15/2021
-ms.author: scottwhi
+ms.author: v-apunnamara
 ---
 
 # Search the web for news

--- a/bing-docs/bing-news-search/how-to/search-for-news.md
+++ b/bing-docs/bing-news-search/how-to/search-for-news.md
@@ -29,7 +29,7 @@ https://api.bing.microsoft.com/v7.0/news/search
 Here's a cURL example that shows you how to call the endpoint using your subscription key. Change the *q* query parameter to search for whatever news you'd like.
 
 ```curl
-curl -H "Ocp-Apim-Subscription-Key: <yourkeygoeshere>" https://api.bing.microsoft.com/bing/v7.0/news/search?q=mt+rainier
+curl -H "Ocp-Apim-Subscription-Key: <yourkeygoeshere>" https://api.bing.microsoft.com/v7.0/news/search?q=mt+rainier
 ```
 
 
@@ -47,7 +47,7 @@ The more information you can provide Bing, the better the search experience will
 Here's a cURL example that includes these headers.
 
 ```curl
-curl -H "Ocp-Apim-Subscription-Key: <yourkeygoeshere>" -H "X-MSEdge-ClientID: 00B4230B74496E7A13CC2C1475056FF4" -H "X-MSEdge-ClientIP: 11.22.33.44" -H "X-Search-Location: lat:55;long:-111;re:22" -A "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.65 Safari/537.36" https://api.bing.microsoft.com/bing/v7.0/news/search?q=mt+rainier
+curl -H "Ocp-Apim-Subscription-Key: <yourkeygoeshere>" -H "X-MSEdge-ClientID: 00B4230B74496E7A13CC2C1475056FF4" -H "X-MSEdge-ClientIP: 11.22.33.44" -H "X-Search-Location: lat:55;long:-111;re:22" -A "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.65 Safari/537.36" https://api.bing.microsoft.com/v7.0/news/search?q=mt+rainier
 ```
 
 Bing returns a couple of headers you should capture. 
@@ -61,7 +61,7 @@ To learn more about these headers, see [Response headers](../reference/headers.m
 Here's a cURL call that returns the response headers. If you want to remove the response data so you can see only the headers, include the `-o nul` parameter.
 
 ```curl
-curl -D - -H "Ocp-Apim-Subscription-Key: <yourkeygoeshere>" https://api.bing.microsoft.com/bing/v7.0/news/search?q=mt+rainier
+curl -D - -H "Ocp-Apim-Subscription-Key: <yourkeygoeshere>" https://api.bing.microsoft.com/v7.0/news/search?q=mt+rainier
 ```
 
 

--- a/bing-docs/bing-news-search/how-to/search-for-news.md
+++ b/bing-docs/bing-news-search/how-to/search-for-news.md
@@ -3,13 +3,13 @@ title: Search for news with the Bing News Search API
 titleSuffix: Bing Search Services
 description: Learn how to send search queries for general news, trending topics, and headlines.
 services: bing-search-services
-author: swhite-msft
+author: alekhyasasi
 manager: ehansen
 
 ms.service: bing-search-services
 ms.subservice: bing-news-search
 ms.topic: conceptual
-ms.date: 07/15/2020
+ms.date: 11/15/2021
 ms.author: scottwhi
 ---
 


### PR DESCRIPTION
Correct URL is https://api.bing.microsoft.com/v7.0/news/search, not https://api.bing.microsoft.com/bing/v7.0/news/search