### PR TITLE
Remove Cognitive Services SDK reference

### DIFF
--- a/bing-docs/bing-spell-check/toc.yml
+++ b/bing-docs/bing-spell-check/toc.yml
@@ -62,18 +62,6 @@
       href: reference/market-codes.md
     - name: Error codes
       href: reference/error-codes.md
-  - name: SDKs (client libraries)
-    items:
-    - name: .NET
-      href: https://docs.microsoft.com/dotnet/api/overview/azure/cognitiveservices/client/bingspellcheck?view=azure-dotnet
-    - name: Node.js
-      href: https://docs.microsoft.com/javascript/api/@azure/cognitiveservices-spellcheck/?view=azure-node-latest
-    - name: Python
-      href: https://docs.microsoft.com/python/api/overview/azure/cognitiveservices/spellcheck?view=azure-python
-    - name: Go
-      href: https://godoc.org/github.com/Azure/azure-sdk-for-go/services/cognitiveservices/v1.0/spellcheck
-    - name: Java
-      href: https://docs.microsoft.com/java/api/overview/azure/cognitiveservices/client/bingspellcheck?view=azure-java-stable
 - name: Resources
   items:
   - name: Create Bing Search Service resource


### PR DESCRIPTION
[Ask](https://msasg.visualstudio.com/Bing_UX/_workitems/edit/3775526/?triage=true)

Fix - The fix should remove references in menus and all content related to SDK across ALL APIs that point to Cognitive.  We shouldn’t have any code samples referring back to Cognitive.

