### PR TITLE
 [Bulk] Broken Link fixes

### DIFF
--- a/bing-docs/bing-autosuggest/quickstarts/sdk/autosuggest-client-library-csharp.md
+++ b/bing-docs/bing-autosuggest/quickstarts/sdk/autosuggest-client-library-csharp.md
@@ -18,7 +18,7 @@ Get started with the Bing Autosuggest client library for .NET. Follow these step
 
 Use the Bing Autosuggest client library for .NET to get search suggestions based on partial query strings.
 
-[Reference documentation](/dotnet/api/overview/azure/cognitiveservices/bing-autosuggest-readme?view=azure-dotnet) | [Library source code](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/cognitiveservices/Search.BingAutoSuggest) | [Package (NuGet)](https://www.nuget.org/packages/Microsoft.Azure.CognitiveServices.Search.AutoSuggest/) | [Sample code](https://github.com/Azure-Samples/cognitive-services-quickstart-code/blob/master/dotnet/BingAutoSuggest/Program.cs)
+[Reference documentation](/dotnet/api/overview/azure/cognitiveservices/bing-autosuggest-readme) | [Library source code](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/cognitiveservices/Search.BingAutoSuggest) | [Package (NuGet)](https://www.nuget.org/packages/Microsoft.Azure.CognitiveServices.Search.AutoSuggest/) | [Sample code](https://github.com/Azure-Samples/cognitive-services-quickstart-code/blob/master/dotnet/BingAutoSuggest/Program.cs)
 
 ## Prerequisites
 
@@ -209,4 +209,4 @@ dotnet run
 ## See also
 
 - [What is Bing Autosuggest?](../../overview.md)
-- [Bing Autosuggest .NET reference](/dotnet/api/overview/azure/cognitiveservices/bing-autosuggest-readme?view=azure-dotnet)
+- [Bing Autosuggest .NET reference](/dotnet/api/overview/azure/cognitiveservices/bing-autosuggest-readme)

--- a/bing-docs/bing-autosuggest/quickstarts/sdk/autosuggest-client-library-csharp.md
+++ b/bing-docs/bing-autosuggest/quickstarts/sdk/autosuggest-client-library-csharp.md
@@ -18,7 +18,7 @@ Get started with the Bing Autosuggest client library for .NET. Follow these step
 
 Use the Bing Autosuggest client library for .NET to get search suggestions based on partial query strings.
 
-[Reference documentation](/dotnet/api/overview/azure/cognitiveservices/client/bingautosuggest?view=azure-dotnet) | [Library source code](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/cognitiveservices/Search.BingAutoSuggest) | [Package (NuGet)](https://www.nuget.org/packages/Microsoft.Azure.CognitiveServices.Search.AutoSuggest/) | [Sample code](https://github.com/Azure-Samples/cognitive-services-quickstart-code/blob/master/dotnet/BingAutoSuggest/Program.cs)
+[Reference documentation](/dotnet/api/overview/azure/cognitiveservices/bing-autosuggest-readme?view=azure-dotnet) | [Library source code](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/cognitiveservices/Search.BingAutoSuggest) | [Package (NuGet)](https://www.nuget.org/packages/Microsoft.Azure.CognitiveServices.Search.AutoSuggest/) | [Sample code](https://github.com/Azure-Samples/cognitive-services-quickstart-code/blob/master/dotnet/BingAutoSuggest/Program.cs)
 
 ## Prerequisites
 
@@ -209,4 +209,4 @@ dotnet run
 ## See also
 
 - [What is Bing Autosuggest?](../../overview.md)
-- [Bing Autosuggest .NET reference](/dotnet/api/overview/azure/cognitiveservices/client/bingautosuggest?view=azure-dotnet)
+- [Bing Autosuggest .NET reference](/dotnet/api/overview/azure/cognitiveservices/bing-autosuggest-readme?view=azure-dotnet)

--- a/bing-docs/bing-autosuggest/quickstarts/sdk/autosuggest-client-library-go.md
+++ b/bing-docs/bing-autosuggest/quickstarts/sdk/autosuggest-client-library-go.md
@@ -214,4 +214,4 @@ go run sample-app.go
 ## See also
 
 - [What is Bing Autosuggest?](../../overview.md)
-- [Bing Autosuggest Go reference](/dotnet/api/overview/azure/cognitiveservices/client/bingautosuggest?view=azure-go)
+- Bing Autosuggest Go reference

--- a/bing-docs/bing-autosuggest/samples.md
+++ b/bing-docs/bing-autosuggest/samples.md
@@ -22,11 +22,11 @@ Here's a list of REST samples by language. The list is subject to change. For th
 
 |Language|Sample
 |-|-
-|<a href="https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest" target="_blank">C#</a>|<a href="https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingAutosuggestV7.cs" target="_blank">Bing Autosuggest</a>
-|<a href="https://github.com/microsoft/bing-search-java-samples/tree/main/rest" target="_blank">Java</a>|<a href="https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingAutosuggestV7.java" target="_blank">Bing Autosuggest</a>
-|<a href="https://github.com/microsoft/bing-search-nodejs-samples/tree/main/rest" target="_blank">JavaScript</a>|<a href="https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingAutosuggestV7.js" target="_blank">Bing Autosuggest</a>
-|<a href="https://github.com/microsoft/bing-search-python-samples/tree/main/rest" target="_blank">Python</a>|<a href="https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingAutosuggestV7.py" target="_blank">Bing Autosuggest</a>
-|<a href="https://github.com/microsoft/bing-search-ruby-samples/tree/main/rest" target="_blank">Ruby</a>|<a href="https://github.com/microsoft/bing-search-ruby-samples/blob/main/rest/BingAutosuggestV7.rb" target="_blank">Bing Autosuggest</a>
+|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Autosuggest](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingAutosuggestV7.cs)
+|[Java](https://github.com/microsoft/bing-search-java-samples/tree/main/rest)|[Bing Autosuggest](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingAutosuggestV7.java)
+|[JavaScript](https://github.com/microsoft/bing-search-nodejs-samples/tree/main/rest)|[Bing Autosuggest](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingAutosuggestV7.js)
+|[Python](https://github.com/microsoft/bing-search-python-samples/tree/main/rest)|[Bing Autosuggest](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingAutosuggestV7.py)
+|[Ruby](https://github.com/microsoft/bing-search-ruby-samples/tree/main/rest)|[Bing Autosuggest](https://github.com/microsoft/bing-search-ruby-samples/blob/main/rest/BingAutosuggestV7.rb)
 
 
 ## Samples using the Bing client library
@@ -35,10 +35,10 @@ Here's a list of SDK samples by language. The list is subject to change. For the
 
 |Language|Sample
 |-|-
-|<a href="https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest" target="_blank">C#</a>|<a href="https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs" target="_blank">Bing Autosuggest</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-java-sdk-samples" target="_blank">Java</a>|<a href="https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java" target="_blank">Bing Autosuggest</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-node-sdk-samples" target="_blank">Node.js</a>|<a href="https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js" target="_blank">Bing Autosuggest</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-python-sdk-samples" target="_blank">Python</a>|<a href="https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py" target="_blank">Bing Autosuggest</a>
+|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Autosuggest](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs)
+|[Java](https://github.com/Azure-Samples/cognitive-services-java-sdk-samples)|[Bing Autosuggest](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java)
+|[Node.js](https://github.com/Azure-Samples/cognitive-services-node-sdk-samples)|[Bing Autosuggest](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js)
+|[Python](https://github.com/Azure-Samples/cognitive-services-python-sdk-samples)|[Bing Autosuggest](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py)
 
 
 ## Next steps

--- a/bing-docs/bing-custom-search/quickstarts/sdk/custom-search-client-library-csharp.md
+++ b/bing-docs/bing-custom-search/quickstarts/sdk/custom-search-client-library-csharp.md
@@ -20,7 +20,7 @@ Use the Bing Custom Search client library for C# to:
 
 - Find search results on the web, from your Bing Custom Search instance.
 
-[Reference documentation](/dotnet/api/overview/azure/cognitiveservices/client/bingcustomsearch?view=azure-dotnet) | [Library source code](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/cognitiveservices/Search.BingCustomSearch) | [Package (NuGet)](https://www.nuget.org/packages/Microsoft.Azure.CognitiveServices.Search.CustomSearch/1.2.0) | [Samples](https://github.com/Azure-Samples/cognitive-services-dotnet-sdk-samples)
+Reference documentation | [Library source code](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/cognitiveservices/Search.BingCustomSearch) | [Package (NuGet)](https://www.nuget.org/packages/Microsoft.Azure.CognitiveServices.Search.CustomSearch/1.2.0) | [Samples](https://github.com/Azure-Samples/cognitive-services-dotnet-sdk-samples)
 
 ## Prerequisites
 

--- a/bing-docs/bing-custom-search/quickstarts/sdk/custom-search-client-library-csharp.md
+++ b/bing-docs/bing-custom-search/quickstarts/sdk/custom-search-client-library-csharp.md
@@ -25,7 +25,7 @@ Reference documentation | [Library source code](https://github.com/Azure/azure-s
 ## Prerequisites
 
 - A Bing Custom Search instance. See [Quickstart: Create your first Bing Custom Search instance](../../how-to/quick-start.md) for more information.
-- Microsoft [.NET Core](https://www.microsoft.com/net/download/core).
+- Microsoft [.NET Core](https://dotnet.microsoft.com/download).
 - Any edition of [Visual Studio 2017 or later](https://www.visualstudio.com/downloads/).
 - If you are using Linux/MacOS, this application can be run using [Mono](https://www.mono-project.com/).
 - The [Bing Custom Search](https://www.nuget.org/packages/Microsoft.Azure.CognitiveServices.Search.CustomSearch/1.2.0)  NuGet package.

--- a/bing-docs/bing-custom-search/samples.md
+++ b/bing-docs/bing-custom-search/samples.md
@@ -22,10 +22,10 @@ Here's a list of REST samples by language. The list is subject to change. For th
 
 |Language|Sample
 |-|-
-|<a href="https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest" target="_blank">C#</a>|<a href="https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingCustomSearchV7.cs" target="_blank">Bing Custom Search</a>
-|<a href="https://github.com/microsoft/bing-search-java-samples/tree/main/rest" target="_blank">Java</a>|<a href="https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingCustomSearchV7.java" target="_blank">Bing Custom Search</a>
-|<a href="https://github.com/microsoft/bing-search-nodejs-samples/tree/main/rest" target="_blank">JavaScript</a>|<a href="https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingCustomSearchV7.js" target="_blank">Bing Custom Search</a>
-|<a href="https://github.com/microsoft/bing-search-python-samples/tree/main/rest" target="_blank">Python</a>|<a href="https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingCustomSearchV7.py" target="_blank">Bing Custom Search</a>
+|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Custom Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingCustomSearchV7.cs)
+|[Java](https://github.com/microsoft/bing-search-java-samples/tree/main/rest)|[Bing Custom Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingCustomSearchV7.java)
+|[JavaScript](https://github.com/microsoft/bing-search-nodejs-samples/tree/main/rest)|[Bing Custom Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingCustomSearchV7.js)
+|[Python](https://github.com/microsoft/bing-search-python-samples/tree/main/rest)|[Bing Custom Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingCustomSearchV7.py)
 
 
 
@@ -35,10 +35,10 @@ Here's a list of SDK samples by language. The list is subject to change. For the
 
 |Language|Sample
 |-|-
-|<a href="https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest" target="_blank">C#</a>|<a href="https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs" target="_blank">Bing Custom Search</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-java-sdk-samples" target="_blank">Java</a>|<a href="https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java" target="_blank">Bing Custom Search</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-node-sdk-samples" target="_blank">Node.js</a>|<a href="https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js" target="_blank">Bing Custom Search</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-python-sdk-samples" target="_blank">Python</a>|<a href="https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py" target="_blank">Bing Custom Search</a>
+|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Custom Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs)
+|[Java](https://github.com/Azure-Samples/cognitive-services-java-sdk-samples)|[Bing Custom Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java)
+|[Node.js](https://github.com/Azure-Samples/cognitive-services-node-sdk-samples)|[Bing Custom Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js)
+|[Python](https://github.com/Azure-Samples/cognitive-services-python-sdk-samples)|[Bing Custom Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py)
 
 
 ## Next steps

--- a/bing-docs/bing-entity-search/release-notes.md
+++ b/bing-docs/bing-entity-search/release-notes.md
@@ -17,7 +17,7 @@ See the following sections for information about changes that were included with
 
 ## October 30, 2020
 
-Initial release of this version of Bing Entity Search API. This API replaces the same API hosted by <a href="https://learn.microsoft.com/azure/cognitive-services/bing-entity-search/" target="_blank">Azure Cognitive Services</a>, which is being phased out. 
+Initial release of this version of Bing Entity Search API. This API replaces the same API hosted by [Azure Cognitive Services](/azure/cognitive-services/what-are-cognitive-services), which is being phased out. 
 
 ### New to Bing Search?
 
@@ -32,4 +32,4 @@ Things current Cognitive Services users must do prior to their subscription endi
   
 2. Update your app to use the new endpoints. For the new endpoints, see [Entity Search API](reference/endpoints.md) reference.
 
-If you use <a href="https://learn.microsoft.com/azure/cognitive-services/bing-local-business-search/local-search-reference" target="_blank">Local Business Search API</a>, it's not available in Bing Search Services. 
+If you use [Local Business Search API](/azure/cognitive-services/bing-local-business-search/local-search-reference), it's not available in Bing Search Services. 

--- a/bing-docs/bing-entity-search/samples.md
+++ b/bing-docs/bing-entity-search/samples.md
@@ -22,11 +22,11 @@ Here's a list of REST samples by language. The list is subject to change. For th
 
 |Language|Sample
 |-|-
-|<a href="https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest" target="_blank">C#</a>|<a href="https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingEntitySearchV7.cs" target="_blank">Bing Entity Search</a>
-|<a href="https://github.com/microsoft/bing-search-java-samples/tree/main/rest" target="_blank">Java</a>|<a href="https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingEntitySearchV7.java" target="_blank">Bing Entity Search</a>
-|<a href="https://github.com/microsoft/bing-search-nodejs-samples/tree/main/rest" target="_blank">JavaScript</a>|<a href="https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingEntitySearchV7.js" target="_blank">Bing Entity Search</a>
-|<a href="https://github.com/microsoft/bing-search-python-samples/tree/main/rest" target="_blank">Python</a>|<a href="https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingEntitySearchV7.py" target="_blank">Bing Entity Search</a>
-|<a href="https://github.com/microsoft/bing-search-ruby-samples/tree/main/rest" target="_blank">Ruby</a>|<a href="https://github.com/microsoft/bing-search-ruby-samples/blob/main/rest/BingEntitySearchV7.rb" target="_blank">Bing Entity Search</a>
+|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Entity Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingEntitySearchV7.cs)
+|[Java](https://github.com/microsoft/bing-search-java-samples/tree/main/rest)|[Bing Entity Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingEntitySearchV7.java)
+|[JavaScript](https://github.com/microsoft/bing-search-nodejs-samples/tree/main/rest)|[Bing Entity Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingEntitySearchV7.js)
+|[Python](https://github.com/microsoft/bing-search-python-samples/tree/main/rest)|[Bing Entity Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingEntitySearchV7.py)
+|[Ruby](https://github.com/microsoft/bing-search-ruby-samples/tree/main/rest)|[Bing Entity Search](https://github.com/microsoft/bing-search-ruby-samples/blob/main/rest/BingEntitySearchV7.rb)
 
 
 ## Samples using the Bing client library
@@ -35,10 +35,10 @@ Here's a list of SDK samples by language. The list is subject to change. For the
 
 |Language|Sample
 |-|-
-|<a href="https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest" target="_blank">C#</a>|<a href="https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs" target="_blank">Bing Entity Search</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-java-sdk-samples" target="_blank">Java</a>|<a href="https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java" target="_blank">Bing Entity Search</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-node-sdk-samples" target="_blank">Node.js</a>|<a href="https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js" target="_blank">Bing Entity Search</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-python-sdk-samples" target="_blank">Python</a>|<a href="https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py" target="_blank">Bing Entity Search</a>
+|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Entity Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs)
+|[Java](https://github.com/Azure-Samples/cognitive-services-java-sdk-samples)|[Bing Entity Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java)
+|[Node.js](https://github.com/Azure-Samples/cognitive-services-node-sdk-samples)|[Bing Entity Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js)
+|[Python](https://github.com/Azure-Samples/cognitive-services-python-sdk-samples)|[Bing Entity Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py)
 
 
 ## Next steps

--- a/bing-docs/bing-image-search/samples.md
+++ b/bing-docs/bing-image-search/samples.md
@@ -22,11 +22,11 @@ Here's a list of REST samples by language. The list is subject to change. For th
 
 |Language|Sample
 |-|-
-|<a href="https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest" target="_blank">C#</a>|<a href="https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingImageSearchV7.cs" target="_blank">Bing Image Search</a>
-|<a href="https://github.com/microsoft/bing-search-java-samples/tree/main/rest" target="_blank">Java</a>|<a href="https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingImageSearchV7.java" target="_blank">Bing Image Search</a>
-|<a href="https://github.com/microsoft/bing-search-nodejs-samples/tree/main/rest" target="_blank">JavaScript</a>|<a href="https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingImageSearchV7.js" target="_blank">Bing Image Search</a>
-|<a href="https://github.com/microsoft/bing-search-python-samples/tree/main/rest" target="_blank">Python</a>|<a href="https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingImageSearchV7.py" target="_blank">Bing Image Search</a>
-|<a href="https://github.com/microsoft/bing-search-ruby-samples/tree/main/rest" target="_blank">Ruby</a>|<a href="https://github.com/microsoft/bing-search-ruby-samples/blob/main/rest/BingImageSearachV7.rb" target="_blank">Bing Image Search</a>
+|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Image Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingImageSearchV7.cs)
+|[Java](https://github.com/microsoft/bing-search-java-samples/tree/main/rest)|[Bing Image Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingImageSearchV7.java)
+|[JavaScript](https://github.com/microsoft/bing-search-nodejs-samples/tree/main/rest)|[Bing Image Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingImageSearchV7.js)
+|[Python](https://github.com/microsoft/bing-search-python-samples/tree/main/rest)|[Bing Image Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingImageSearchV7.py)
+|[Ruby](https://github.com/microsoft/bing-search-ruby-samples/tree/main/rest)|[Bing Image Search](https://github.com/microsoft/bing-search-ruby-samples/blob/main/rest/BingImageSearachV7.rb)
 
 
 ## Samples using the Bing client library
@@ -35,10 +35,10 @@ Here's a list of SDK samples by language. The list is subject to change. For the
 
 |Language|Sample
 |-|-
-|<a href="https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest" target="_blank">C#</a>|<a href="https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs" target="_blank">Bing Image Search</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-java-sdk-samples" target="_blank">Java</a>|<a href="https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java" target="_blank">Bing Image Search</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-node-sdk-samples" target="_blank">Node.js</a>|<a href="https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js" target="_blank">Bing Image Search</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-python-sdk-samples" target="_blank">Python</a>|<a href="https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py" target="_blank">Bing Image Search</a>
+|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Image Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs)
+|[Java](https://github.com/Azure-Samples/cognitive-services-java-sdk-samples)|[Bing Image Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java)
+|[Node.js](https://github.com/Azure-Samples/cognitive-services-node-sdk-samples)|[Bing Image Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js)
+|[Python](https://github.com/Azure-Samples/cognitive-services-python-sdk-samples)|[Bing Image Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py)
 
 
 ## Next steps

--- a/bing-docs/bing-news-search/samples.md
+++ b/bing-docs/bing-news-search/samples.md
@@ -22,11 +22,11 @@ Here's a list of REST samples by language. The list is subject to change. For th
 
 |Language|Sample
 |-|-
-|<a href="https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest" target="_blank">C#</a>|<a href="https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingNewsSearchV7.cs" target="_blank">Bing News Search</a>
-|<a href="https://github.com/microsoft/bing-search-java-samples/tree/main/rest" target="_blank">Java</a>|<a href="https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingNewsSearchV7.java" target="_blank">Bing News Search</a>
-|<a href="https://github.com/microsoft/bing-search-nodejs-samples/tree/main/rest" target="_blank">JavaScript</a>|<a href="https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingNewsSearchV7.js" target="_blank">Bing News Search</a>
-|<a href="https://github.com/microsoft/bing-search-python-samples/tree/main/rest" target="_blank">Python</a>|<a href="https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingNewsSearchV7.py" target="_blank">Bing News Search</a>
-|<a href="https://github.com/microsoft/bing-search-ruby-samples/tree/main/rest" target="_blank">Ruby</a>|<a href="https://github.com/microsoft/bing-search-ruby-samples/blob/main/rest/BingNewsSearchV7.rb" target="_blank">Bing News Search</a>
+|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing News Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingNewsSearchV7.cs)
+|[Java](https://github.com/microsoft/bing-search-java-samples/tree/main/rest)|[Bing News Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingNewsSearchV7.java)
+|[JavaScript](https://github.com/microsoft/bing-search-nodejs-samples/tree/main/rest)|[Bing News Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingNewsSearchV7.js)
+|[Python](https://github.com/microsoft/bing-search-python-samples/tree/main/rest)|[Bing News Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingNewsSearchV7.py)
+|[Ruby](https://github.com/microsoft/bing-search-ruby-samples/tree/main/rest)|[Bing News Search](https://github.com/microsoft/bing-search-ruby-samples/blob/main/rest/BingNewsSearchV7.rb)
 
 
 ## Samples using the Bing client library
@@ -35,10 +35,10 @@ Here's a list of SDK samples by language. The list is subject to change. For the
 
 |Language|Sample
 |-|-
-|<a href="https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest" target="_blank">C#</a>|<a href="https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs" target="_blank">Bing News Search</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-java-sdk-samples" target="_blank">Java</a>|<a href="https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java" target="_blank">Bing News Search</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-node-sdk-samples" target="_blank">Node.js</a>|<a href="https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js" target="_blank">Bing News Search</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-python-sdk-samples" target="_blank">Python</a>|<a href="https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py" target="_blank">Bing News Search</a>
+|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing News Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs)
+|[Java](https://github.com/Azure-Samples/cognitive-services-java-sdk-samples)|[Bing News Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java)
+|[Node.js](https://github.com/Azure-Samples/cognitive-services-node-sdk-samples)|[Bing News Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js)
+|[Python](https://github.com/Azure-Samples/cognitive-services-python-sdk-samples)|[Bing News Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py)
 
 
 ## Next steps

--- a/bing-docs/bing-spell-check/quickstarts/sdk/spell-check-client-library-csharp.md
+++ b/bing-docs/bing-spell-check/quickstarts/sdk/spell-check-client-library-csharp.md
@@ -102,4 +102,4 @@ Build and run your project. If you're using Visual Studio, press **F5** to debug
 > [Create a single page web-app](../../tutorial/spellcheck.md)
 
 - [What is the Bing Spell Check API?](../../overview.md)
-- [Bing Spell Check C# SDK reference guide](/dotnet/api/overview/azure/cognitiveservices/client/bingspellcheck?view=azure-dotnet)
+- Bing Spell Check C# SDK reference guide

--- a/bing-docs/bing-spell-check/samples.md
+++ b/bing-docs/bing-spell-check/samples.md
@@ -22,11 +22,11 @@ Here's a list of REST samples by language. The list is subject to change. For th
 
 |Language|Sample
 |-|-
-|<a href="https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest" target="_blank">C#</a>|<a href="https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingSpellCheckV7.cs" target="_blank">Bing Spell Check</a>
-|<a href="https://github.com/microsoft/bing-search-java-samples/tree/main/rest" target="_blank">Java</a>|<a href="https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingSpellCheckV7.java" target="_blank">Bing Spell Check</a>
-|<a href="https://github.com/microsoft/bing-search-nodejs-samples/tree/main/rest" target="_blank">JavaScript</a>|<a href="https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingSpellCheckV7.js" target="_blank">Bing Spell Check</a>
-|<a href="https://github.com/microsoft/bing-search-python-samples/tree/main/rest" target="_blank">Python</a>|<a href="https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingSpellCheckV7.py" target="_blank">Bing Spell Check</a>
-|<a href="https://github.com/microsoft/bing-search-ruby-samples/tree/main/rest" target="_blank">Ruby</a>|<a href="https://github.com/microsoft/bing-search-ruby-samples/blob/main/rest/BingSpellCheckV7.rb" target="_blank">Bing Spell Check</a>
+|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Spell Check](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingSpellCheckV7.cs)
+|[Java](https://github.com/microsoft/bing-search-java-samples/tree/main/rest)|[Bing Spell Check](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingSpellCheckV7.java)
+|[JavaScript](https://github.com/microsoft/bing-search-nodejs-samples/tree/main/rest)|[Bing Spell Check](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingSpellCheckV7.js)
+|[Python](https://github.com/microsoft/bing-search-python-samples/tree/main/rest)|[Bing Spell Check](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingSpellCheckV7.py)
+|[Ruby](https://github.com/microsoft/bing-search-ruby-samples/tree/main/rest)|[Bing Spell Check](https://github.com/microsoft/bing-search-ruby-samples/blob/main/rest/BingSpellCheckV7.rb)
 
 
 ## Samples using the Bing client library
@@ -35,10 +35,10 @@ Here's a list of SDK samples by language. The list is subject to change. For the
 
 |Language|Sample
 |-|-
-|<a href="https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest" target="_blank">C#</a>|<a href="https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs" target="_blank">Bing Spell Check</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-java-sdk-samples" target="_blank">Java</a>|<a href="https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java" target="_blank">Bing Spell Check</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-node-sdk-samples" target="_blank">Node.js</a>|<a href="https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js" target="_blank">Bing Spell Check</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-python-sdk-samples" target="_blank">Python</a>|<a href="https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py" target="_blank">Bing Spell Check</a>
+|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Spell Check](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs)
+|[Java](https://github.com/Azure-Samples/cognitive-services-java-sdk-samples)[Bing Spell Check](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java)
+|[Node.js](https://github.com/Azure-Samples/cognitive-services-node-sdk-samples)|[Bing Spell Check](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js)
+|[Python](https://github.com/Azure-Samples/cognitive-services-python-sdk-samples)|[Bing Spell Check](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py)
 
 
 ## Next steps

--- a/bing-docs/bing-video-search/reference/endpoints.md
+++ b/bing-docs/bing-video-search/reference/endpoints.md
@@ -26,9 +26,9 @@ To request video search results, send a GET request to one of the following endp
   
 |Endpoint|Description
 |-|-
-|<https://api.bing.microsoft.com/v7.0/videos/search>|Returns videos that are relevant to the user's search query.
-|<https://api.bing.microsoft.com/v7.0/videos/details>|Returns insights about a video, such as related videos.
-|<https://api.bing.microsoft.com/v7.0/videos/trending>|Returns videos that are trending based on search requests made by others. The videos are broken out into different categories. For example, Top Music Videos. For a list of markets that support trending videos, see [Supported trending videos markets](market-codes.md#trending-video-api-markets).
+|`https://api.bing.microsoft.com/v7.0/videos/search`|Returns videos that are relevant to the user's search query.
+|`https://api.bing.microsoft.com/v7.0/videos/details`|Returns insights about a video, such as related videos.
+|`https://api.bing.microsoft.com/v7.0/videos/trending`|Returns videos that are trending based on search requests made by others. The videos are broken out into different categories. For example, Top Music Videos. For a list of markets that support trending videos, see [Supported trending videos markets](market-codes.md#trending-video-api-markets).
 
 The request must use the HTTPS protocol.
 

--- a/bing-docs/bing-video-search/samples.md
+++ b/bing-docs/bing-video-search/samples.md
@@ -22,11 +22,11 @@ Here's a list of REST samples by language. The list is subject to change. For th
 
 |Language|Sample
 |-|-
-|<a href="https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest" target="_blank">C#</a>|<a href="https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingVideoSearchV7.cs" target="_blank">Bing Video Search</a>
-|<a href="https://github.com/microsoft/bing-search-java-samples/tree/main/rest" target="_blank">Java</a>|<a href="https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingVideoSearchV7.java" target="_blank">Bing Video Search</a>
-|<a href="https://github.com/microsoft/bing-search-nodejs-samples/tree/main/rest" target="_blank">JavaScript</a>|<a href="https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingVideoSearchV7.js" target="_blank">Bing Video Search</a>
-|<a href="https://github.com/microsoft/bing-search-python-samples/tree/main/rest" target="_blank">Python</a>|<a href="https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingVideoSearchV7.py" target="_blank">Bing Video Search</a>
-|<a href="https://github.com/microsoft/bing-search-ruby-samples/tree/main/rest" target="_blank">Ruby</a>|<a href="https://github.com/microsoft/bing-search-ruby-samples/blob/main/rest/BingVideoSearchV7.rb" target="_blank">Bing Video Search</a>
+|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Video Search](ttps://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingVideoSearchV7.cs)
+|[Java](https://github.com/microsoft/bing-search-java-samples/tree/main/rest)|[Bing Video Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingVideoSearchV7.java)
+|[JavaScript](https://github.com/microsoft/bing-search-nodejs-samples/tree/main/rest)|[Bing Video Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingVideoSearchV7.js)
+|[Python](https://github.com/microsoft/bing-search-python-samples/tree/main/rest)|[Bing Video Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingVideoSearchV7.py)
+|[Ruby](https://github.com/microsoft/bing-search-ruby-samples/tree/main/rest)|[Bing Video Search](https://github.com/microsoft/bing-search-ruby-samples/blob/main/rest/BingVideoSearchV7.rb)
 
 
 ## Samples using the Bing client library
@@ -35,10 +35,10 @@ Here's a list of SDK samples by language. The list is subject to change. For the
 
 |Language|Sample
 |-|-
-|<a href="https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest" target="_blank">C#</a>|<a href="https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs" target="_blank">Bing Video Search</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-java-sdk-samples" target="_blank">Java</a>|<a href="https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java" target="_blank">Bing Video Search</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-node-sdk-samples" target="_blank">Node.js</a>|<a href="https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js" target="_blank">Bing Video Search</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-python-sdk-samples" target="_blank">Python</a>|<a href="https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py" target="_blank">Bing Video Search</a>
+|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Video Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs)
+|[Java](https://github.com/Azure-Samples/cognitive-services-java-sdk-samples)|[Bing Video Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java)
+|[Node.js](https://github.com/Azure-Samples/cognitive-services-node-sdk-samples)|[Bing Video Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js)
+|[Python](https://github.com/Azure-Samples/cognitive-services-python-sdk-samples)|[Bing Video Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py)
 
 
 ## Next steps

--- a/bing-docs/bing-video-search/samples.md
+++ b/bing-docs/bing-video-search/samples.md
@@ -22,7 +22,7 @@ Here's a list of REST samples by language. The list is subject to change. For th
 
 |Language|Sample
 |-|-
-|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Video Search](ttps://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingVideoSearchV7.cs)
+|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Video Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingVideoSearchV7.cs)
 |[Java](https://github.com/microsoft/bing-search-java-samples/tree/main/rest)|[Bing Video Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingVideoSearchV7.java)
 |[JavaScript](https://github.com/microsoft/bing-search-nodejs-samples/tree/main/rest)|[Bing Video Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingVideoSearchV7.js)
 |[Python](https://github.com/microsoft/bing-search-python-samples/tree/main/rest)|[Bing Video Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingVideoSearchV7.py)

--- a/bing-docs/bing-visual-search/quickstarts/sdk/visual-search-client-library-csharp.md
+++ b/bing-docs/bing-visual-search/quickstarts/sdk/visual-search-client-library-csharp.md
@@ -16,7 +16,7 @@ ms.author: scottwhi
 
 Use this quickstart to begin getting image insights from the Bing Visual Search service, using the C# client library. While Bing Visual Search has a REST API compatible with most programming languages, the client library provides an easy way to integrate the service into your applications. The source code for this sample can be found on [GitHub](https://github.com/Azure-Samples/cognitive-services-dotnet-sdk-samples/tree/master/BingSearchv7/BingVisualSearch).
 
-[Reference documentation](/dotnet/api/overview/azure/cognitiveservices/client/bingvisualsearch?view=azure-dotnet&preserve-view=true) | [Library source code](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/cognitiveservices/Search.BingVisualSearch) | [Package (NuGet)](https://www.nuget.org/packages/Microsoft.Azure.CognitiveServices.Search.VisualSearch/) | [Samples](https://github.com/Azure-Samples/cognitive-services-dotnet-sdk-samples/)
+[Reference documentation](/dotnet/api/overview/azure/cognitiveservices/bing-visual-search-readme?view=azure-dotnet) | [Library source code](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/cognitiveservices/Search.BingVisualSearch) | [Package (NuGet)](https://www.nuget.org/packages/Microsoft.Azure.CognitiveServices.Search.VisualSearch/) | [Samples](https://github.com/Azure-Samples/cognitive-services-dotnet-sdk-samples/)
 
 ## Prerequisites
 

--- a/bing-docs/bing-visual-search/quickstarts/sdk/visual-search-client-library-csharp.md
+++ b/bing-docs/bing-visual-search/quickstarts/sdk/visual-search-client-library-csharp.md
@@ -16,7 +16,7 @@ ms.author: scottwhi
 
 Use this quickstart to begin getting image insights from the Bing Visual Search service, using the C# client library. While Bing Visual Search has a REST API compatible with most programming languages, the client library provides an easy way to integrate the service into your applications. The source code for this sample can be found on [GitHub](https://github.com/Azure-Samples/cognitive-services-dotnet-sdk-samples/tree/master/BingSearchv7/BingVisualSearch).
 
-[Reference documentation](/dotnet/api/overview/azure/cognitiveservices/bing-visual-search-readme?view=azure-dotnet) | [Library source code](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/cognitiveservices/Search.BingVisualSearch) | [Package (NuGet)](https://www.nuget.org/packages/Microsoft.Azure.CognitiveServices.Search.VisualSearch/) | [Samples](https://github.com/Azure-Samples/cognitive-services-dotnet-sdk-samples/)
+[Reference documentation](/dotnet/api/overview/azure/cognitiveservices/bing-visual-search-readme) | [Library source code](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/cognitiveservices/Search.BingVisualSearch) | [Package (NuGet)](https://www.nuget.org/packages/Microsoft.Azure.CognitiveServices.Search.VisualSearch/) | [Samples](https://github.com/Azure-Samples/cognitive-services-dotnet-sdk-samples/)
 
 ## Prerequisites
 

--- a/bing-docs/bing-visual-search/reference/response-objects.md
+++ b/bing-docs/bing-visual-search/reference/response-objects.md
@@ -56,7 +56,7 @@ Defines an entity such as a person, place, or thing.
 |Name|Value|Type
 |-|-|-
 |bingId|An ID that uniquely identifies this entity.|String  
-|contractualRules|A list of rules that you must adhere to if you display the entity. For example, the rules may govern attribution of the entity's description.<br/><br/>The following contractual rules may apply:<ul><li>[LicenseAttribution](#licenseattribution)</li><li>[LinkAttribution](#linkattribution)</li><li>[MediaAttribution](#mediaattribution)</li><li>[TextAttribution](#textattribution)</li></ul>Not all entities include rules. If the entity provides contractual rules, you must abide by them. For more information about using contractual rules, see [Attributing Data](/../../bing-entities-search/concepts/data-attribution).|Object[]
+|contractualRules|A list of rules that you must adhere to if you display the entity. For example, the rules may govern attribution of the entity's description.<br/><br/>The following contractual rules may apply:<ul><li>[LicenseAttribution](#licenseattribution)</li><li>[LinkAttribution](#linkattribution)</li><li>[MediaAttribution](#mediaattribution)</li><li>[TextAttribution](#textattribution)</li></ul>Not all entities include rules. If the entity provides contractual rules, you must abide by them. For more information about using contractual rules, see [Attributing Data](/bing/search-apis/bing-web-search/data-attribution).|Object[]
 |description|A short description of the entity.|String  
 |image|An image of the entity.|[Image](#image)
 |name|The entity's name.|String

--- a/bing-docs/bing-visual-search/samples.md
+++ b/bing-docs/bing-visual-search/samples.md
@@ -22,10 +22,10 @@ Here's a list of REST samples by language. The list is subject to change. For th
 
 |Language|Sample
 |-|-
-|<a href="https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest" target="_blank">C#</a>|<a href="https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingVisualSearchV7.cs" target="_blank">Bing Visual Search</a>
-|<a href="https://github.com/microsoft/bing-search-java-samples/tree/main/rest" target="_blank">Java</a>|<a href="https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingVisualSearchV7.java" target="_blank">Bing Visual Search</a>
-|<a href="https://github.com/microsoft/bing-search-nodejs-samples/tree/main/rest" target="_blank">JavaScript</a>|<a href="https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingVisualSearchV7.js" target="_blank">Bing Visual Search</a>
-|<a href="https://github.com/microsoft/bing-search-python-samples/tree/main/rest" target="_blank">Python</a>|<a href="https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingVisualSearchV7.py" target="_blank">Bing Visual Search</a>
+|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Visual Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingVisualSearchV7.cs")
+|[Java](https://github.com/microsoft/bing-search-java-samples/tree/main/rest)|[Bing Visual Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingVisualSearchV7.java)
+|[JavaScript](https://github.com/microsoft/bing-search-nodejs-samples/tree/main/rest)[Bing Visual Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingVisualSearchV7.js)
+|[Python](https://github.com/microsoft/bing-search-python-samples/tree/main/rest)|[Bing Visual Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingVisualSearchV7.py)
 
 
 ## Samples using the Bing client library
@@ -34,10 +34,10 @@ Here's a list of SDK samples by language. The list is subject to change. For the
 
 |Language|Sample
 |-|-
-|<a href="https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest" target="_blank">C#</a>|<a href="https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs" target="_blank">Bing Visual Search</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-java-sdk-samples" target="_blank">Java</a>|<a href="https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java" target="_blank">Bing Visual Search</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-node-sdk-samples" target="_blank">Node.js</a>|<a href="https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js" target="_blank">Bing Visual Search</a>
-|<a href="https://github.com/Azure-Samples/cognitive-services-python-sdk-samples" target="_blank">Python</a>|<a href="https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py" target="_blank">Bing Visual Search</a>
+|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Visual Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs)
+|[Java](https://github.com/Azure-Samples/cognitive-services-java-sdk-samples)|[Bing Visual Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java)
+|[Node.js](https://github.com/Azure-Samples/cognitive-services-node-sdk-samples)|[Bing Visual Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js)
+|[Python](https://github.com/Azure-Samples/cognitive-services-python-sdk-samples)|[Bing Visual Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py)</a>
 
 
 ## Next steps

--- a/bing-docs/bing-visual-search/samples.md
+++ b/bing-docs/bing-visual-search/samples.md
@@ -22,7 +22,7 @@ Here's a list of REST samples by language. The list is subject to change. For th
 
 |Language|Sample
 |-|-
-|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Visual Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingVisualSearchV7.cs")
+|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Visual Search](https://github.com/microsoft/bing-search-java-samples/tree/main/rest)
 |[Java](https://github.com/microsoft/bing-search-java-samples/tree/main/rest)|[Bing Visual Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingVisualSearchV7.java)
 |[JavaScript](https://github.com/microsoft/bing-search-nodejs-samples/tree/main/rest)[Bing Visual Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingVisualSearchV7.js)
 |[Python](https://github.com/microsoft/bing-search-python-samples/tree/main/rest)|[Bing Visual Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingVisualSearchV7.py)

--- a/bing-docs/bing-web-search/index.yml
+++ b/bing-docs/bing-web-search/index.yml
@@ -280,23 +280,23 @@ additionalContent:
       - title: .NET SDK
         links:
           - text: Bing Web Search
-            url: /dotnet/api/overview/azure/cognitiveservices/client/bingwebsearchapi?view=azure-dotnet
+            url: /dotnet/api/overview/azure/cognitiveservices/bing-web-search-api-readme?view=azure-dotnet
           - text: Bing Custom Search
-            url: /dotnet/api/overview/azure/cognitiveservices/client/bingcustomsearch?view=azure-dotnet
+            url: /dotnet/api/overview/azure/cognitiveservices/bing-custom-search-readme?view=azure-dotnet
           - text: Bing Entity Search
-            url: /dotnet/api/overview/azure/cognitiveservices/client/bingentitysearchapi?view=azure-dotnet
+            url: /dotnet/api/overview/azure/cognitiveservices/bing-entity-search-api-readme?view=azure-dotnet
           - text: Bing Image Search
-            url: /dotnet/api/overview/azure/cognitiveservices/client/bingimagesearch?view=azure-dotnet
+            url: /dotnet/api/overview/azure/cognitiveservices/bing-image-search-readme?view=azure-dotnet
           - text: Bing News Search
-            url: /dotnet/api/overview/azure/cognitiveservices/client/bingnewssearch?view=azure-dotnet
+            url: dotnet/api/overview/azure/cognitiveservices/bing-news-search-readme?view=azure-dotnet
           - text: Bing Video Search
-            url: /dotnet/api/overview/azure/cognitiveservices/client/bingvideosearch?view=azure-dotnet
+            url: /dotnet/api/overview/azure/cognitiveservices/bing-video-search-readme?view=azure-dotnet
           - text: Bing Visual Search
-            url: /dotnet/api/overview/azure/cognitiveservices/client/bingvisualsearch?view=azure-dotnet
+            url: /dotnet/api/overview/azure/cognitiveservices/bing-visual-search-readme?view=azure-dotnet
           - text: Bing Spell Check
-            url: /dotnet/api/overview/azure/cognitiveservices/client/bingspellcheck?view=azure-dotnet
+            url: /dotnet/api/overview/azure/cognitiveservices/bing-spell-check-readme?view=azure-dotnet
           - text: Bing Autosuggest
-            url: /dotnet/api/overview/azure/cognitiveservices/client/bingautosuggest?view=azure-dotnet
+            url: /dotnet/api/overview/azure/cognitiveservices/bing-autosuggest-readme?view=azure-dotnet
       - title: Java SDK
         links:
           - text: Bing Web Search
@@ -320,21 +320,20 @@ additionalContent:
       - title: Python SDK
         links:
           - text: Bing Web Search
-            url: /python/api/overview/azure/cognitiveservices/websearch?view=azure-python
+            url: /python/api/overview/azure/cognitiveservices/bing-web-search-api-readme?view=azure-python
           - text: Bing Custom Search
-            url: /python/api/overview/azure/cognitiveservices/customsearch?view=azure-python
+            url: /python/api/overview/azure/cognitiveservices/bing-custom-search-readme?view=azure-python
           - text: Bing Entity Search
-            url: /python/api/overview/azure/cognitiveservices/entitysearch?view=azure-python
+            url: /python/api/overview/azure/cognitiveservices/bing-entity-search-api-readme?view=azure-python
           - text: Bing Image Search
-            url: /python/api/overview/azure/cognitiveservices/imagesearch?view=azure-python
+            url: /python/api/overview/azure/cognitiveservices/bing-image-search-readme?view=azure-python
           - text: Bing News Search
-            url: /python/api/overview/azure/cognitiveservices/newssearch?view=azure-python
+            url: /python/api/overview/azure/cognitiveservices/bing-news-search-readme?view=azure-python
           - text: Bing Video Search
-            url: /python/api/overview/azure/cognitiveservices/videosearch?view=azure-python
+            url: /python/api/overview/azure/cognitiveservices/bing-video-search-readme?view=azure-python
           - text: Bing Visual Search
-            url: /python/api/overview/azure/cognitiveservices/visualsearch?view=azure-python
-          - text: Bing Spell Check
-            url: /python/api/overview/azure/cognitiveservices/spellcheck?view=azure-python
+            url: /python/api/overview/azure/cognitiveservices/bing-visual-search-readme?view=azure-python
+          
       - title: Node.js SDK
         links:
           - text: Bing Web Search

--- a/bing-docs/bing-web-search/index.yml
+++ b/bing-docs/bing-web-search/index.yml
@@ -288,7 +288,7 @@ additionalContent:
           - text: Bing Image Search
             url: /dotnet/api/overview/azure/cognitiveservices/bing-image-search-readme?view=azure-dotnet
           - text: Bing News Search
-            url: dotnet/api/overview/azure/cognitiveservices/bing-news-search-readme?view=azure-dotnet
+            url: /dotnet/api/overview/azure/cognitiveservices/bing-news-search-readme?view=azure-dotnet
           - text: Bing Video Search
             url: /dotnet/api/overview/azure/cognitiveservices/bing-video-search-readme?view=azure-dotnet
           - text: Bing Visual Search


### PR DESCRIPTION
**Global effort to fix broken links**

@jaggerbodas-ms 
@AlekhyaSasi 
@arwong 

The C+E Skilling team is fixing broken links on learn.microsoft.com for the rest of H2. This effort will eliminate potential accessibility, security, and usability issues. This PR includes only link fixes or removes and does not change other content. I’d very much appreciate your timely review and feedback on the link changes I’ve suggested. Thanks!

