### PR TITLE
Replace LLM use and display requirements text with actual text

### DIFF
--- a/bing-docs/bing-web-search/use-display-requirements-llm.md
+++ b/bing-docs/bing-web-search/use-display-requirements-llm.md
@@ -8,7 +8,7 @@ manager: ehansen
 ms.service: bing-search-services
 ms.subservice: bing-web-search
 ms.topic: conceptual
-ms.date: 06/01/2023
+ms.date: 06/13/2023
 ---
 
 # Use and Display requirements of Bing Search APIs, with your LLM
@@ -16,291 +16,97 @@ ms.date: 06/01/2023
 > [!NOTE]
 > The Use and Display requirements on this page apply to the Bing Search APIs, with your LLM. For Use and Display Requirements specific to using the Bing Search APIs, refer [here](use-display-requirements.md).
 
-These terms of use (*TOU*) apply to your use of the Services and Content, including LLM Use, all as defined below. By installing, accessing, or otherwise using the Services within your Application (defined below), you are agreeing to these TOU with Microsoft Corporation (**"Microsoft"**, **"we"**, **"us"**, or **"our"**). You represent and warrant to us that you have the authority to accept this TOU on behalf of yourself, a company, or another entity, as applicable (**"you"** or **"Company"**). We may change, amend, or cancel this TOU at any time. Your use of the Services after the changes become effective means you agree to the new TOU. If you do not agree to the new TOU, you must stop using the Services.
+These Bing Search APIs, with your LLM use and display requirements apply to any implementation of the content and associated information from the following Bing Search APIs, including relationships, metadata, and other signals. Specific terms apply to use of Bing Search APIs, with your LLM used in connection with large language models (LLMs), see "LLM use and display requirements" below.
+- Bing Entity Search
+- Bing Image Search
+- Bing News Search
+- Bing Video Search
+- Bing Web Search
+- Bing Spell Check
+- Bing Autosuggest
+
+Note use of Bing Custom Search and Bing Visual Search is not included in Bing Search APIs, with your LLM. 
 
 ## Definitions
+|Term|Description
+|-|-
+|Answer|A category of results returned in a response. For example, a response from the Bing Web Search API can include answers in the categories of webpage results, image, video, and news.
+|Grounding|The process of connecting an LLM's output to the real world by allowing the model to temporarily access and use the output of the results to augment the specific output of the model for that single query and user, but not for the purposes of training the model with such data for future use.
+|LLM(s)|Large language model(s).
+|Response|Any and all answers and associated data received in response to a single call to a Search API.
+|Result|An item of information in an answer. For example, the set of data connected with a single news article is a result in a news answer.
+|Search APIs|Collectively, Entity Search, Image Search, News Search, Video Search, and Web Search APIs.
+|Web Results|The top ten webpage results ("blue links") returned from the Bing Web Search API.
 
-Wherever used in these TOU with the first letter capitalized, these terms have the following meanings:
+## Bing Spell Check and Bing Autosuggest API restrictions
 
-Term | Description
----- | ---------
-<a name="API"></a>API | Any form of application programming interface that provides access to a Microsoft service and any associated tools, including sample code that enables interactions with Microsoft's services, and documentation that Microsoft makes available under these TOU, and includes all elements, components, and executables of such API.
-<a name="Application"></a>Application | Your software application, website, or product you create or a service you offer designed to provide access to the Services.
-<a name="Bing Search APIs, with your LLM Use and Display Requirements"></a>Bing Search APIs, with your LLM Use and Display Requirements | The use and display terms applicable to use of the [Bing Search APIs, with your LLM](use-display-requirements-llm.md) (as may be updated from time to time).
-<a name="Bing Search APIs, with your LLM"></a>Bing Search APIs, with your LLM | Collectively indicate the following APIs available through the Azure Marketplace: Entity Search, Image Search, News Search, Video Search and Web Search APIs. It does not include Bing Custom Search or Bing Visual Search.  
-<a name="Bing Search Services Data"></a>Bing Search Services Data | Data provided to Microsoft by, or on behalf of, you through use of the Services.
-<a name="Content"></a>Content | Any search results, images, data, third party content, or other content that Microsoft makes available to you via the Services.
-<a name="Documentation"></a>Documentation | The software development kits and technical documentation applicable to the Services available [here](../index.yml) or otherwise provided to you by Microsoft.
-<a name="End User"></a>End User | The users of your Application.
-<a name="Grounding"></a>Grounding | The process of connecting an LLM's output to the real world by allowing the model to temporarily access and use the output of the results to augment the specific output of the model for that single query and user, but not for the purposes of training the model with such data for future use.
-<a name="LLM(s)"></a>LLM(s) | Large language model(s).
-<a name="LLM Use"></a>LLM Use | Refer to [LLM use](#5-llm-use).
-<a name="Offer Details"></a>Offer Details | The pricing and related terms applicable to the Services, as made available by Microsoft and [here](https://www.microsoft.com/bing/apis/pricing).
-<a name="Services"></a>Services | (i) Bing Search APIs, with your LLM that provide access to Content, including all elements, components and executables of such APIs and <br>(ii) Documentation that Microsoft makes available under these TOU.
-<a name="Standard Terms"></a>Standard Terms | The agreement under which you obtained access to the Services: <br> - For customers who purchase the Services online from Microsoft, your use is governed by either the Microsoft Customer Agreement ("MCA"), or the Microsoft Online Subscription Agreement ("MOSA"). <br> - For customers who purchase the Services through another Microsoft Commercial Licensing Program, such as an Enterprise Agreement, your use is governed by the licensing agreement under which you purchased the services. You can obtain a copy of your licensing agreement by contacting your Microsoft account representative or Commercial Licensing.
-<a name="Web Results"></a>Web Results | The top ten webpage results (“blue links”) returned from the Bing Web Search API.
+**Do not:**
 
-## License grants
+- Copy, store, or cache any data you receive from the Bing Spell Check or Bing Autosuggest APIs.
+- Use data you receive from the Bing Spell Check or Bing Autosuggest APIs as part of any machine learning or similar algorithmic activity. Do not use this data to train, evaluate, or improve new or existing services that you or third parties might offer.
+- Display data received from the Bing Spell Check or Bing Autosuggest APIs on the same page as content from any general web search engine, LLMs (except as permitted below) or advertising network.
+- Attribute to Microsoft responses (or parts of responses) displayed from the Bing Spell Check or Bing Autosuggest APIs, unless Microsoft specifies otherwise in writing for your particular use.
 
-#### 1. Use of the Service and Content
+## Bing Search APIs
 
-Expressly conditioned upon your compliance with these TOU, subject to the restrictions and requirements in this section, and solely during the term of these TOU, Microsoft grants you a limited, non-exclusive, non-assignable, non-transferable, revocable license to:
+**Note**
 
-1. install, use, and make calls to the Services to develop, test, and support your Application and to allow End Users to use your integration of the Services within your Application and
+The requirements in this section apply to only the Search APIs, which does not include Bing Spell Check or Bing Autosuggest. This section applies to use and display of Responses from the Search APIs.
 
-1. to use the Content, as it is provided by the Services, in your Application. You may use the Services using only the methods and means of access that are documented in the Documentation.
+When using in connection with LLMs specific additional terms apply, see "LLM use and display requirements" below.
 
-#### 2. Attribution and proprietary notices
+### Internet search experience requirements
 
-Microsoft grants you a non-exclusive, non-assignable, non-transferable, revocable license to reproduce and display Microsoft's logos in the Content in connection with your authorized use of the Services for the sole purpose of providing attribution to Microsoft as required by the Bing Search APIs, with your LLM Use and Display Requirements. If the Content includes Microsoft's or its suppliers' logos or proprietary notices, you will not change, obscure, remove, or resize any logo, trademark, copyright, or other notice of Microsoft or its suppliers or digital watermarks in the Content. If such notices are not included in the Content, unless otherwise noted in the Bing Search APIs, with your LLM Use and Display Requirements, you must display in a conspicuous manner within your Application the Microsoft or third party attribution provided by Microsoft.
+All data returned in Responses may only be used in internet search experiences. An internet search experience means the content displayed:
 
-#### 3. No Derivative Works
+- Is relevant and responsive to the end user's direct query, or other indication of their search interest and intent (for example, a user-indicated search query).
+- Helps users find and navigate to the response's data sources. For example, providing clickable links from hyperlinks in the response.
+- Includes multiple results for the user to select from.
+- Are in a placement that enables users to search.
+- Includes a visible indication that the content is an internet search result. For example, a statement that the content is "from the web".
+- Includes any other appropriate measures to ensure your Bing Search API data does not violate any applicable laws or rights of, or duties or obligations owed by you to, third parties. Consult your legal advisors to determine what measures may be appropriate.
 
-You will not modify or create a derivative work based on any Content unless expressly permitted to do so under these TOU.
+### Restrictions
 
-#### 4. Bing Search APIs, with your LLM Use and Display Requirements
+**Do not:**
 
-You must comply with the Bing Search APIs, with your [LLM Use and Display Requirements](use-display-requirements-llm.md). You must use results you obtain through the Services only in Internet Search Experiences (as defined in the Bing Search APIs, with your LLM Use and Display Requirements) and you must not cache or copy results.
+- Copy, store, or cache any data from Responses.
+- Use data received from the Search APIs as part of any machine learning or similar algorithmic activity. Do not use this data to train, evaluate, or improve new or existing services that you or third parties might offer.
+- Display data received from the Search APIs on the same page as content from any general web search engine, LLMs (except as permitted below) or advertising network.
+- Modify the results content (other than to reformat them in a way that does not violate any other requirement), unless required by law or agreed to by Microsoft.
+- Omit attribution information and URLs associated with results content.
+- Reorder, including by omission, the results displayed in an answer when an order or ranking is provided, unless required by law or agreed to by Microsoft.
+- Attribute to Microsoft Responses (or parts of Responses) displayed from the Search APIs, unless Microsoft specifies otherwise in writing for your particular use.   
+- Display content that was not included within any part of a Response in a way that would lead a user to believe that content is part of the Response.
+- Display advertising that is not provided by Microsoft on any page that displays any part of a Response.
+- Display any advertising on pages with Responses:
+  - From the Bing Image, News Search, or Video Search APIs, or
+  - That are filtered or limited primarily (or solely) to image, news and/or video results.
 
-#### 5. LLM Use
+### Privacy Notice
 
-You are granted a non-exclusive, non-assignable, non-transferable, revocable license to:
+**Do:**
+- Prominently include a functional hyperlink to the [Microsoft Privacy Statement](https://go.microsoft.com/fwlink/?LinkId=521839), near each point in the user experience (UX) that offers a user the ability to input a search query. Label the hyperlink **Microsoft Privacy Statement**.
 
-1. display Content received from the Bing Search APIs, with your LLM on the same webpage as content from an LLM;
+## LLM use and display requirements for Search APIs, Bing Spell Check API and Bing Autosuggest API
 
-1. use Web Results only for Grounding an LLM, including your own, proprietary LLM and display respective source attribution as set forth in the Bing Search APIs, with your LLM Use and Display Requirements (**LLM Use**). For the avoidance of doubt, you may not use any Content (including, without limitation, web, images, videos, news entity data, auto suggest, spell etc.) to train any LLM, including your proprietary LLM.
+When using Search APIs, Bing Spell Check API, or Bing Autosuggest API in connection with LLMs, you must follow the guidelines below:
 
-Additional requirements and/or restrictions related to LLM Use may be set forth in the Bing Search APIs, with your LLM Use and Display Requirements.
+**You may <u>only</u>:**
 
-## Account Access
+- Display responses received from the Search APIs, Bing Spell Check API and Bing Autosuggest API on the same webpage as content from an LLM, provided the Search APIs, Bing Spell Check API and Bing Autosuggest API responses are clearly separated from the LLM content (e.g. the LLM content should not be inserted in between the Search APIs Results); and/or 
+- Use Web Results for Grounding an LLM.
 
-We will provide you with a security key (**Subscription Key**) when you register that you must use to access the Services. You may not share your Subscription Key with any third party, and you must use the Subscription Key as your sole means of accessing the API. You are responsible for the security and confidentiality of your credentials, including your Subscription Key, and all use of the Services through your credentials. You must notify Microsoft promptly of any possible misuse of your accounts or credentials. You may not create multiple accounts for the purpose of circumventing transaction limits.
+**Do not:**
 
-## Use of the Services
+- Use any responses (including, without limitation, web, images, videos, news, entity data, auto suggest, spell etc.) to train, evaluate or improve any LLM, including your proprietary LLM;
+- Display advertising that is not provided by Microsoft; or 
+- Attribute the Web Results for Grounding your LLM to Microsoft, unless Microsoft specifies otherwise in writing for your particular use.
 
-You may use the Services only as expressly permitted in these TOU and in the Bing Search APIs, with your LLM Use and Display Requirements.
+**LLM Attribution:**
 
-1. Your use of the Services is subject to any additional restrictions or rights included in the Standard Terms. In the event of a conflict between the Standard Terms and these TOU, these TOU will control solely with respect to your use of the Services.
+- You must provide source attribution and a link back to each source that is used for the content being displayed from the LLM, when using Web Results for Grounding an LLM. The source attribution must be near the displayed LLM content. 
 
-1. Microsoft may, in its sole discretion, limit:
+## GDPR compliance
 
-    - the rate at which the Services, or any subset of it, may be called
-    - the amount of storage made available to each Services account or
-    - the length of individual content segments that may be uploaded to, or served from, the Services.
-
-When using the Services, you may not, nor may you permit third parties or your End Users to:
-
-1. Use the Services in any application or situation where failure of the Services could lead to the death or serious bodily injury of any person or to severe physical or environmental damage.
-
-1. Use the Services in a way that could impair, harm, or damage Microsoft, any Microsoft service or application, anyone's use of the Services, or any other Microsoft service or application.
-
-1. Use the Services to disrupt, interfere with, or attempt to gain unauthorized access to services, servers, or networks connected to or that can be accessed via the Services.
-
-1. Use the Services in a way that violates applicable law, including:
-
-    - Illegal activities, such as child pornography, gambling, piracy, or violating copyright, trademark, or other intellectual property laws
-    - Intending to exploit minors in any way
-    - Accessing or authorizing anyone to access the Bing Search APIs, with your LLM from an embargoed country
-    - Threatening, stalking, defaming, defrauding, degrading, victimizing or intimidating anyone for any reason; or
-    - Violating applicable privacy laws and regulations
-
-1. Reverse engineer, decompile, or disassemble Services, except and only to the extent that applicable law expressly permits, despite this limitation.
-
-1. Use the Services to create a database or service that competes with Content received when using the Services.
-
-1. Use of the Content may not be used in combination with any open source software or other data subject to an open source license that may impair the copyright protection of the Content.
-
-1. Use Services in any way that threatens the integrity, performance, or reliability of Services or any Microsoft product or service, including performance or stress testing, or in any manner that works around any technical limitations in Services.
-
-1. Request from a Service more than the minimum data that your Application needs to offer End Users the intended Application functionality.
-
-1. Request from a Service any information outside any permissions granted by the End User of your Application, if a Service requires permissions.
-
-1. Redistribute, resell, or sublicense access to any Microsoft service or Content.
-
-1. Falsify or alter any unique referral identifier in, or assigned to, an Application, or otherwise obscure or alter the source of queries coming from an Application.
-
-1. Circumvent or bypass transaction limits by any means or in any manner, including by creating multiple accounts or
-
-1. Copy, store, archive, or create a database of Content.
-
-Additional restrictions may apply to use of particular Content or functionalities, as set forth in the Documentation from time to time.
-
-## Fees and payment
-
-#### Pricing and payment
-
-Refer to [pricing and payment terms](https://www.microsoft.com/bing/apis/pricing).
-
-#### Taxes
-
-Prices are exclusive of any taxes unless otherwise specified on the invoice as tax inclusive. You must pay any applicable value added, goods and services, sales, gross receipts, or other transaction taxes, fees, charges or surcharges, or any regulatory cost recovery surcharges or similar amounts that are owed under this agreement and which Microsoft is permitted to collect from you under applicable law. You will be responsible for any applicable stamp taxes and for all other taxes that you are legally obligated to pay. Microsoft will be responsible for all taxes based on its net income, gross receipts taxes imposed in lieu of taxes on income or profits, or taxes on its property ownership.
-
-If any taxes are required to be withheld on payments you make to Microsoft, you may deduct such taxes from the amount owed to Microsoft and pay them to the appropriate taxing authority; provided, however, that you promptly secure and deliver an official receipt for those withholdings and other documents Microsoft reasonably requests to claim a foreign tax credit or refund. You must ensure that any taxes withheld are minimized to the extent possible under applicable law.
-
-## Data collection and privacy
-
-**Microsoft may collect information from you or End Users such as, but not limited to, an End User's IP address, requests, time of submissions and the results returned to the End User, in connection with transaction requests to the Services.** All access to and use of the Services, including Microsoft's processing of Bing Search Services Data, is subject to the data practices set forth in the then-current Privacy Statement, a current copy of which is available at <https://privacy.microsoft.com/en-us/privacystatement>. You are responsible for providing End Users with adequate notice of the privacy practices applicable to your Application.
-
-Bing Search Services Data and Content are not Customer Data, as defined in the Standard Terms. The Privacy and Security Terms of the Microsoft Product Terms do not apply to the Services. Microsoft's processing, storage and use of Bing Search Services Data and Content is set forth in the Privacy Statement.
-
-## Intellectual Property and Reservation of Rights
-
-#### Reservation of rights
-
-All rights to the Services and the Content, including rights of use, not specifically granted under these TOU are reserved by Microsoft and its suppliers.
-
-#### Ownership
-
-Except for material that we may license to you, we do not claim ownership of any data, information, or content that you upload or otherwise provide to us related to the Services. Except as set expressly stated in these TOU, these TOU do not grant Microsoft any right or license to any Application or your intellectual property, including intellectual property that you have licensed from third parties.
-
-## Disclaimer of Warranties
-
-Notwithstanding anything to the contrary in the Standard Terms, the Services and all Content are provided **"as is"** without warranty or SLA of any kind by Microsoft or its suppliers. To the maximum extent permitted by law, any and all representations, warranties, or conditions of any kind whatsoever (including, but not limited to, implied or statutory warranties of merchantability, fitness for a particular purpose, title, non-infringement, accuracy or satisfactory quality), all with regard to the Services and any Content, are expressly excluded by Microsoft and its suppliers. Microsoft and its suppliers make no warranty that the Services will operate properly as integrated with the Applications, that the Services will be uninterrupted, or that any Content will be accurate or complete. Microsoft and its suppliers specifically disclaim any liability for End Users' reliance on the Services. Without limiting the foregoing, Microsoft and its suppliers will not be liable for harm to End Users resulting from reliance on any Content provided hereunder.
-
-## Disclaimer of consequential damages
-
-Neither party nor Microsoft's suppliers will be liable for any indirect damages (including, without limitation, consequential, special or incidental damages, damages for loss of profits or revenues, business interruption, or loss of business information), arising out of or related to the Services, Content, or these TOU, even if advised of the possibility of such damages or if the possibility was reasonably foreseeable.
-
-## Limitation of Liability
-
-The aggregate liability of each party for all claims under this agreement is limited to direct damages up to the amount paid under this Agreement during the 12 months before the cause of action arose.  None of the limitations and exclusions in [Disclaimer of consequential damages](#disclaimer-of-consequential-damages) or [Limitation of Liability](#limitation-of-liability) apply to claims related to either party's violation of the other party's intellectual property rights or to any obligation to pay fees or to either party's [defense obligations](#5-obligations).
-
-## Defense
-
-#### 1. By Microsoft
-
-Microsoft will defend you against any claims made by an unaffiliated third party that the Services infringe that third party's patent, copyright or trademark or makes unlawful use of its trade secret.
-
-#### 2. By you
-
-You will defend Microsoft against any claims made by an unaffiliated third party that:
-
-1. any Application, Bing Search Services Data, product or services you provide, directly or indirectly, in using the Services infringes the third party's patent, copyright, or trademark or makes unlawful use of its trade secret;
-1. arises out of LLM Use; or
-1. arises from violation of [LLM use](#5-llm-use), [Use of the services](#use-of-the-services), or the Bing Search APIs, with your LLM Use and Display Requirements.
-
-#### 3. Limitations
-
-Microsoft's obligations in the [section 1](#1-by-microsoft) will not apply to a claim or award based on:
-
-1. any Application, Bing Search Services Data, third party product or service, modifications you make to the Services, or services or materials you provide or make available as part of using the Services
-1. your combination of the Product with, or damages based upon the value of, your Application, Bing Search Services Data, or any third party product, service, data, or business process
-1. your use of a Microsoft trademark without our express written consent, or your use of the Services after we notify you to stop due to a third-party claim.
-1. your redistribution of the Services to, or use for the benefit of, any unaffiliated third party
-1. LLM Use
-1. Services provided free of charge
-
-#### 4. Remedies
-
-If we reasonably believe that a claim under [section 1](#1-by-microsoft) may bar your use of the Services, we will seek to:
-
-1. obtain the right for you to keep using it or
-1. modify or replace it with a functional equivalent and notify you to stop use of the prior version of the Services. If these options are not commercially reasonable, we may terminate your rights to use the Services and then refund any advance payments for unused Services.
-
-#### 5. Obligations
-
-Each party must notify the other promptly of a claim under this Section. The party seeking protection must
-
-1. give the other sole control over the defense and settlement of the claim
-1. give reasonable help in defending the claim.
-
-The party providing the protection will
-
-1. reimburse the other for reasonable out-of-pocket expenses that it incurs in giving that help and
-1. pay the amount of any resulting adverse final judgment or settlement.
-
-The parties' respective rights to defense and payment of judgments (or settlement the other consents to) under this section are in lieu of any common law or statutory indemnification rights or analogous rights, and each party waives such common law or statutory rights.
-
-## Term and termination
-
-These TOU are effective upon your acceptance. Either party may terminate these TOU if the other party is in breach of any material term and fails to cure it within 30 days after written notice that describes the breach. In the event of termination by Microsoft due to your uncured material breach, all rights granted to you by these TOU will automatically terminate and you will cease to have any rights to use the Services and all unpaid amounts for Services delivered prior to termination automatically become due and payable. Microsoft may revoke the [LLM Use rights granted above](#5-llm-use) at any time upon 30 days written notice.
-
-## Services updates
-
-We may change the Services at any time. Some changes to the Services may cause your Applications to stop working. Microsoft will make commercially reasonable efforts to provide you with advance notice of material changes or updates to the Services.
-
-## Suspension
-
-We may suspend your use of the Services if:
-
-1. it is reasonably needed to protect the security of the Services, any third parties or any other Microsoft product or service
-1. you fail to respond to a claim under [Defense Section](#defense) within a reasonable time
-1. you do not pay amounts due under this agreement or
-1. you violate the terms of this TOU
-
-If Microsoft suspends your use of the Services, Microsoft will suspend only to the extent reasonably necessary; provided, however, that in the event of a violation of the [LLM Use terms](#5-llm-use), Microsoft may suspend your access to all Services immediately, with or without notice. Unless Microsoft believes an immediate suspension is required or you have violated the LLM Use terms, Microsoft will provide reasonable notice before suspending the Services for the reasons stated above. We will give at least 30 days' notice before suspending for non-payment. If you do not fully address the reasons for the suspension within 60 days after we suspend (or within 7 days after we suspend for violation of the [LLM Use terms](#5-llm-use)), we may terminate your access to the Services. We may also terminate your access to the Services if your use is suspended more than twice in any 12-month period.
-
-## Changes to the TOU
-
-We may update these TOU from time to time. We will notify you of any changes as provided by [Notices](#notices). If you do not agree to the changes, then you must stop using the Services. If you do not stop using the Services, then your use of the Services will continue under the changed TOU. If we choose to change the fees for the Services, Microsoft will provide notice of such terms as provided in [Notices](#notices), and you may elect to stop using the Services rather than incurring fees.
-
-## Notices
-
-We will send any legal notices under this TOU, including notices required by law, to the email address associated with your Microsoft Azure Marketplace account. You are responsible for keeping your contact information up to date. Notices provided to you via email will be deemed given and received on the transmission date of the email. If you do not consent to receive notices electronically, you must stop using the Services.
-
-## Compliance with laws
-
-You must comply with all laws and regulations applicable to you and your End Users' use of Services, including laws related to privacy, data protection, and U.S. export laws.
-
-## Miscellaneous
-
-##### Assignment
-
-You may not assign or delegate any rights or obligations under these TOU, including in connection with a change of control, without Microsoft's prior written consent. Any purported assignment and delegation will be ineffective. We may freely assign or delegate all rights and obligations under these TOU, fully or partially without notice to you.
-
-##### Force majeure
-
-Microsoft and Company will not be in default if performance is delayed or prevented for reasons beyond its control, so long as it resumes performance as soon as practical.
-
-##### Survival
-
-The following sections will survive the termination of this TOU:
-
-- [No Derivative Works](#3-no-derivative-works)
-- [Bing Search APIs, with your LLM Use and Display Requirements](#4-bing-search-apis-with-your-llm-use-and-display-requirements)
-- [Data collection and privacy](#data-collection-and-privacy)
-- [Disclaimer of Warranties](#disclaimer-of-warranties)
-- [Disclaimer of consequential damages](#disclaimer-of-consequential-damages)
-- [Limitation of Liability](#limitation-of-liability)
-- [Defense](#defense)
-- [Compliance with laws](#compliance-with-laws)
-- [Miscellaneous](#miscellaneous)
-
-##### Choice of law and location for resolving disputes
-
-If you are headquartered anywhere other than Europe:
-
-1. Washington State law governs the interpretation of these TOU and applies to claims for breach, regardless of conflict of laws principles and
-1. you and we irrevocably consent to the exclusive jurisdiction and venue of the state or federal courts in King County, Washington, USA, for all disputes arising out of or relating to this TOU.
-
-If you are headquartered in Europe:
-
-1. the laws of England and Wales govern the interpretation of this TOU and apply to claims for breach, regardless of conflict of laws principles and
-1. you and we irrevocably consent to the exclusive jurisdiction and venue of the courts located in London, England, for all disputes arising out of or relating to these TOU.
-
-The parties waive all defenses of lack of personal jurisdiction and forum non conveniens. Process may be served on either party in the manner authorized by applicable law or court rule. In any dispute relating to these TOU, the prevailing party will be entitled to recover reasonable attorneys' fees and costs.
-
-##### Enforceability and interpreting the TOU
-
-All parts of these TOU apply to the maximum extent permitted by law. These TOU, together with your Standard Terms, constitute the entire agreement between you and us regarding your use of the Services. In the event of any conflict between these TOU and your Standard Terms, the Standard Terms will prevail.
-
-##### No third party beneficiaries
-
-These TOU are solely for your and our benefit. It is not for the benefit of any other person, except for permitted successors and assigns.
-
-##### No joint venture
-
-The parties are operating as independent contractors, and nothing in these TOU will be construed as creating a partnership, franchise, joint venture, employer-employee or agency relationship.
-
-##### Waiver
-
-Any delay or failure of either party to exercise a right or remedy will not result in a waiver of that, or any other, right or remedy. No waiver will be effective unless made in writing and signed by an authorized representative of the waiving party.
-
-##### Logos; marketing
-
-Except as otherwise agreed to by the parties in writing, neither party will use any logo or trademark of the other party for marketing or any other purpose without the other party's prior written approval.
-
-##### U.S. export jurisdiction
-
-The Services are subject to U.S. export jurisdiction. You must comply with all applicable laws, including the U.S. Export Administration Regulations, the International Traffic in Arms Regulations, and end-user, end-use and destination restrictions issued by U.S. and other governments.
+With respect to any personal data subject to the European Union General Data Protection Regulation (GDPR) and that is processed in connection with calls to the Search APIs, Bing Spell Check API, or Bing Autosuggest API, you understand that you and Microsoft are independent data controllers under the GDPR. You are independently responsible for your compliance with the GDPR.


### PR DESCRIPTION
The Use and Display requirements with LLM page was mistakenly published with the terms of use. This change replaces page content with the correct text.