### PR TITLE
Updated feedback from "GitHub" to "Standard" (UUF)

### DIFF
--- a/bing-docs/docfx.json
+++ b/bing-docs/docfx.json
@@ -41,8 +41,7 @@
     "globalMetadata": {
       "breadcrumb_path": "/bing/search-apis/breadcrumb/toc.json",
       "extendBreadcrumb": true,
-      "feedback_system": "GitHub",
-      "feedback_github_repo": "MicrosoftDocs/bing-docs",
+      "feedback_system": "Standard",
       "defaultDevLang": "csharp",
       "searchScope": ["Bing Search"],
       "uhfHeaderId": "MSDocsHeader-BingSearch"


### PR DESCRIPTION
Changed feedback system from "GitHub" (deprecated) to "Standard" UUF.