### PR TITLE
Revert bing-web-search ToC to show 'use and display reqs'

### DIFF
--- a/bing-docs/bing-web-search/toc.yml
+++ b/bing-docs/bing-web-search/toc.yml
@@ -100,5 +100,9 @@
       href: https://aka.ms/bingapisupport
     - name: Stack Overflow
       href: https://stackoverflow.com/search?q=bing+web+search
+#- name: Use and display requirements
+#  href: Use-display-requirements.md
+#- name: Use and display requirements with your LLM
+#  href: use-display-requirements-llm.md
 - name: Release notes
   href: release-notes.md


### PR DESCRIPTION
Revert bing-web-search `ToC.md` to show again the 'use and display requirements' pages.