### PR TITLE
Bing Image Search: Update samples/QS links to latest repo/library

### DIFF
--- a/bing-docs/bing-image-search/quickstarts/sdk/image-search-client-library-csharp.md
+++ b/bing-docs/bing-image-search/quickstarts/sdk/image-search-client-library-csharp.md
@@ -9,14 +9,14 @@ ms.service: bing-search-services
 ms.subservice: bing-image-search
 ms.topic: quickstart
 ms.date: 07/15/2020
-ms.author: scottwhi
+ms.author: v-grvanp
 ---
 
 # Quickstart: Use the Bing Image Search .NET client library
 
 Use this quickstart to make your first image search using the Bing Image Search client library, which is a wrapper for the API and contains the same features. This simple C# application sends an image search query, parses the JSON response, and displays the URL of the first image returned.
 
-The source code for this sample is available [on GitHub](https://github.com/Azure-Samples/cognitive-services-dotnet-sdk-samples/tree/master/BingSearchv7/BingImageSearch) with additional error handling and annotations.
+The source code for this sample is available [on GitHub](https://github.com/microsoft/bing-search-sdk-for-net/tree/main/samples/BingSearchSamples/BingImageSearch/quickstart) with additional error handling and annotations.
 
 ## Prerequisites
 * Any edition of [Visual Studio 2017 or later](https://visualstudio.microsoft.com/vs/whatsnew/).
@@ -93,5 +93,5 @@ if (imageResults != null)
 ## See also
 
 * [What is Bing Image Search?](../../overview.md)  
-* [.NET samples for the Azure Cognitive Services SDK](https://github.com/Azure-Samples/cognitive-services-dotnet-sdk-samples/tree/master/BingSearchv7)
+* [.NET samples for the Bing Image Search SDK](https://github.com/microsoft/bing-search-sdk-for-net/tree/main/samples/BingSearchSamples/BingImageSearch)
 * [Bing Image Search API reference](../../reference/endpoints.md)

--- a/bing-docs/bing-image-search/quickstarts/sdk/image-search-client-library-csharp.md
+++ b/bing-docs/bing-image-search/quickstarts/sdk/image-search-client-library-csharp.md
@@ -9,7 +9,7 @@ ms.service: bing-search-services
 ms.subservice: bing-image-search
 ms.topic: quickstart
 ms.date: 07/15/2020
-ms.author: v-grvanp
+ms.author: v-grvanpelt
 ---
 
 # Quickstart: Use the Bing Image Search .NET client library

--- a/bing-docs/bing-image-search/quickstarts/sdk/image-search-client-library-java.md
+++ b/bing-docs/bing-image-search/quickstarts/sdk/image-search-client-library-java.md
@@ -9,7 +9,7 @@ ms.service: bing-search-services
 ms.subservice: bing-image-search
 ms.topic: quickstart
 ms.date: 07/15/2020
-ms.author: v-grvanp
+ms.author: v-grvanpelt
 ---
 
 # Quickstart: Use the Bing Image Search Java client library

--- a/bing-docs/bing-image-search/quickstarts/sdk/image-search-client-library-java.md
+++ b/bing-docs/bing-image-search/quickstarts/sdk/image-search-client-library-java.md
@@ -9,14 +9,14 @@ ms.service: bing-search-services
 ms.subservice: bing-image-search
 ms.topic: quickstart
 ms.date: 07/15/2020
-ms.author: scottwhi
+ms.author: v-grvanp
 ---
 
 # Quickstart: Use the Bing Image Search Java client library
 
 Use this quickstart to make your first image search using the Bing Image Search client library, which is a wrapper for the API and contains the same features. This simple Java application sends an image search query, parses the JSON response, and displays the URL of the first image returned.
 
-The source code for this sample is available [on GitHub](https://github.com/Azure-Samples/cognitive-services-java-sdk-samples/tree/master/Search/BingImageSearch/Quickstart) with additional error handling and annotations.
+The source code for this sample is available [on GitHub](https://github.com/microsoft/bing-search-sdk-for-java/tree/main/samples/sdk/ImageSearchSample) with additional error handling and annotations.
 
 ## Prerequisites
 
@@ -97,5 +97,5 @@ else {
 ## See also
 
 * [What is Bing Image Search?](../../overview.md)  
-* [Java samples for the Azure Cognitive Services SDK](https://github.com/Azure-Samples/cognitive-services-java-sdk-samples)
+* [Java samples for the Bing Image Search SDK](https://github.com/microsoft/bing-search-sdk-for-java/tree/main/samples/sdk/ImageSearchSample)
 * [Bing Image Search API reference](../../reference/endpoints.md)

--- a/bing-docs/bing-image-search/quickstarts/sdk/image-search-client-library-python.md
+++ b/bing-docs/bing-image-search/quickstarts/sdk/image-search-client-library-python.md
@@ -9,7 +9,7 @@ ms.service: bing-search-services
 ms.subservice: bing-image-search
 ms.topic: quickstart
 ms.date: 07/15/2020
-ms.author: v-grvanp
+ms.author: v-grvanpelt
 ---
 
 # Quickstart: Use the Bing Image Search Python client library

--- a/bing-docs/bing-image-search/quickstarts/sdk/image-search-client-library-python.md
+++ b/bing-docs/bing-image-search/quickstarts/sdk/image-search-client-library-python.md
@@ -9,14 +9,14 @@ ms.service: bing-search-services
 ms.subservice: bing-image-search
 ms.topic: quickstart
 ms.date: 07/15/2020
-ms.author: scottwhi
+ms.author: v-grvanp
 ---
 
 # Quickstart: Use the Bing Image Search Python client library
 
 Use this quickstart to make your first image search using the Bing Image Search client library, which is a wrapper for the API and contains the same features. This simple Python application sends an image search query, parses the JSON response, and displays the URL of the first image returned.
 
-The source code for this sample is available [on GitHub](https://github.com/Azure-Samples/cognitive-services-python-sdk-samples/blob/master/samples/search/image-search-quickstart.py) with additional error handling and annotations.
+The source code for this sample is available [on GitHub](https://github.com/microsoft/bing-search-sdk-for-python/blob/main/samples/sdk/image-search-quickstart.py) with additional error handling and annotations.
 
 ## Prerequisites
 
@@ -82,6 +82,6 @@ else:
 ## See also
 
 * [What is Bing Image Search?](../../overview.md)  
-* [Python samples for the Azure Cognitive Services SDK](https://github.com/Azure-Samples/cognitive-services-python-sdk-samples)  
+* [Python samples for the Bing Image Search SDK](https://github.com/microsoft/bing-search-sdk-for-python/blob/main/samples/sdk/image_search_samples.py)  
 * [Bing Image Search API reference](../../reference/endpoints.md)
 

--- a/bing-docs/bing-image-search/samples.md
+++ b/bing-docs/bing-image-search/samples.md
@@ -9,7 +9,7 @@ ms.service: bing-search-services
 ms.subservice: bing-image-search
 ms.topic: sample
 ms.date: 07/15/2020
-ms.author: v-grvanp
+ms.author: v-grvanpelt
 ---
 
 # Bing Image Search API samples

--- a/bing-docs/bing-image-search/samples.md
+++ b/bing-docs/bing-image-search/samples.md
@@ -35,10 +35,10 @@ Here's a list of SDK samples by language. The list is subject to change. For the
 
 |Language|Sample
 |-|-
-|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Image Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs)
-|[Java](https://github.com/Azure-Samples/cognitive-services-java-sdk-samples)|[Bing Image Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java)
-|[Node.js](https://github.com/Azure-Samples/cognitive-services-node-sdk-samples)|[Bing Image Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js)
-|[Python](https://github.com/Azure-Samples/cognitive-services-python-sdk-samples)|[Bing Image Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py)
+|[C#](https://github.com/microsoft/bing-search-sdk-for-net)|[Bing Image Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs)
+|[Java](https://github.com/microsoft/bing-search-sdk-for-java)|[Bing Image Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java)
+|[Node.js](https://github.com/microsoft/bing-search-sdk-for-java)|[Bing Image Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js)
+|[Python](https://github.com/microsoft/bing-search-sdk-for-python)|[Bing Image Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py)
 
 
 ## Next steps

--- a/bing-docs/bing-image-search/samples.md
+++ b/bing-docs/bing-image-search/samples.md
@@ -9,7 +9,7 @@ ms.service: bing-search-services
 ms.subservice: bing-image-search
 ms.topic: sample
 ms.date: 07/15/2020
-ms.author: scottwhi
+ms.author: v-grvanp
 ---
 
 # Bing Image Search API samples
@@ -35,10 +35,10 @@ Here's a list of SDK samples by language. The list is subject to change. For the
 
 |Language|Sample
 |-|-
-|[C#](https://github.com/microsoft/bing-search-sdk-for-net)|[Bing Image Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs)
-|[Java](https://github.com/microsoft/bing-search-sdk-for-java)|[Bing Image Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java)
-|[Node.js](https://github.com/microsoft/bing-search-sdk-for-java)|[Bing Image Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js)
-|[Python](https://github.com/microsoft/bing-search-sdk-for-python)|[Bing Image Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py)
+|[C#](https://github.com/microsoft/bing-search-sdk-for-net/tree/main/samples/BingSearchSamples/BingImageSearch)|[Bing Image Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs)
+|[Java](https://github.com/microsoft/bing-search-sdk-for-java/tree/main/samples/sdk/ImageSearchSample)|[Bing Image Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java)
+|[Node.js](https://github.com/Azure-Samples/cognitive-services-node-sdk-samples)|[Bing Image Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js)
+|[Python](https://github.com/microsoft/bing-search-sdk-for-python/blob/main/samples/sdk/image_search_samples.py)|[Bing Image Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py)
 
 
 ## Next steps


### PR DESCRIPTION
Update SDK Samples/Quick Start links for the Bing Image Search API and remove references to cognitive services
