### PR TITLE
Bing News Search: Update samples/QS links to latest repo/library

### DIFF
--- a/bing-docs/bing-news-search/quickstarts/sdk/news-search-client-library-csharp.md
+++ b/bing-docs/bing-news-search/quickstarts/sdk/news-search-client-library-csharp.md
@@ -9,7 +9,7 @@ ms.service: bing-search-services
 ms.subservice: bing-news-search
 ms.topic: quickstart
 ms.date: 07/15/2020
-ms.author: scottwhi
+ms.author: v-grvanpelt
 ---
 
 # Quickstart: Use the Bing News Search .NET client library

--- a/bing-docs/bing-news-search/quickstarts/sdk/news-search-client-library-csharp.md
+++ b/bing-docs/bing-news-search/quickstarts/sdk/news-search-client-library-csharp.md
@@ -14,7 +14,7 @@ ms.author: scottwhi
 
 # Quickstart: Use the Bing News Search .NET client library
 
-Use this quickstart to begin searching for news with the Bing News Search client library for C#. While Bing News Search has a REST API compatible with most programming languages, the client library provides an easy way to integrate the service into your applications. The source code for this sample can be found on [GitHub](https://github.com/Azure-Samples/cognitive-services-dotnet-sdk-samples/tree/master/BingSearchv7/BingNewsSearch).
+Use this quickstart to begin searching for news with the Bing News Search client library for C#. While Bing News Search has a REST API compatible with most programming languages, the client library provides an easy way to integrate the service into your applications. The source code for this sample can be found on [GitHub](https://github.com/microsoft/bing-search-sdk-for-net/tree/main/samples/BingSearchSamples/BingNewsSearch).
 
 ## Prerequisites
 

--- a/bing-docs/bing-news-search/quickstarts/sdk/news-search-client-library-java.md
+++ b/bing-docs/bing-news-search/quickstarts/sdk/news-search-client-library-java.md
@@ -9,12 +9,12 @@ ms.service: bing-search-services
 ms.subservice: bing-news-search
 ms.topic: quickstart
 ms.date: 07/15/2020
-ms.author: scottwhi
+ms.author: v-grvanpelt
 ---
 
 # Quickstart: Use the Bing News Search Java client library
 
-Use this quickstart to begin searching for news with the Bing News Search client library for Java. While Bing News Search has a REST API compatible with most programming languages, the client library provides an easy way to integrate the service into your applications. The source code for this sample can be found on [GitHub](https://github.com/Azure-Samples/cognitive-services-java-sdk-samples/tree/master/Search/BingNewsSearch).
+Use this quickstart to begin searching for news with the Bing News Search client library for Java. While Bing News Search has a REST API compatible with most programming languages, the client library provides an easy way to integrate the service into your applications. The source code for this sample can be found on [GitHub](https://github.com/microsoft/bing-search-sdk-for-java/tree/main/samples/sdk/NewsSearchSample).
 
 ## Prerequisites
 

--- a/bing-docs/bing-news-search/quickstarts/sdk/news-search-client-library-python.md
+++ b/bing-docs/bing-news-search/quickstarts/sdk/news-search-client-library-python.md
@@ -14,7 +14,7 @@ ms.author: scottwhi
 
 # Quickstart: Use the Bing News Search Python client library
 
-Use this quickstart to begin searching for news with the Bing News Search client library for Python. While Bing News Search has a REST API compatible with most programming languages, the client library provides an easy way to integrate the service into your applications. The source code for this sample can be found on [GitHub](https://github.com/Azure-Samples/cognitive-services-python-sdk-samples/blob/master/samples/search/news_search_samples.py).
+Use this quickstart to begin searching for news with the Bing News Search client library for Python. While Bing News Search has a REST API compatible with most programming languages, the client library provides an easy way to integrate the service into your applications. The source code for this sample can be found on [GitHub](https://github.com/microsoft/bing-search-sdk-for-python/tree/main/samples/sdk).
 
 ## Prerequisites
 

--- a/bing-docs/bing-news-search/quickstarts/sdk/news-search-client-library-python.md
+++ b/bing-docs/bing-news-search/quickstarts/sdk/news-search-client-library-python.md
@@ -9,7 +9,7 @@ ms.service: bing-search-services
 ms.subservice: bing-news-search
 ms.topic: quickstart
 ms.date: 07/15/2020
-ms.author: scottwhi
+ms.author: v-grvanpelt
 ---
 
 # Quickstart: Use the Bing News Search Python client library

--- a/bing-docs/bing-news-search/samples.md
+++ b/bing-docs/bing-news-search/samples.md
@@ -9,7 +9,7 @@ ms.service: bing-search-services
 ms.subservice: bing-news-search
 ms.topic: sample
 ms.date: 07/15/2020
-ms.author: scottwhi
+ms.author: v-grvanpelt
 ---
 
 # Bing News Search API samples
@@ -35,10 +35,10 @@ Here's a list of SDK samples by language. The list is subject to change. For the
 
 |Language|Sample
 |-|-
-|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing News Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs)
-|[Java](https://github.com/Azure-Samples/cognitive-services-java-sdk-samples)|[Bing News Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java)
+|[C#](https://github.com/microsoft/bing-search-sdk-for-net/tree/main/samples/BingSearchSamples/BingNewsSearch)|[Bing News Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs)
+|[Java](https://github.com/microsoft/bing-search-sdk-for-java/tree/main/samples/sdk/NewsSearchSample)|[Bing News Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java)
 |[Node.js](https://github.com/Azure-Samples/cognitive-services-node-sdk-samples)|[Bing News Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js)
-|[Python](https://github.com/Azure-Samples/cognitive-services-python-sdk-samples)|[Bing News Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py)
+|[Python](https://github.com/microsoft/bing-search-sdk-for-python/blob/main/samples/sdk/news_search_samples.py)|[Bing News Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py)
 
 
 ## Next steps


### PR DESCRIPTION
Update SDK Samples/Quick Start links for the Bing News Search API and remove references to cognitive services
