### PR TITLE
Bing Video Search: Update samples/QS links to latest repo/library

### DIFF
--- a/bing-docs/bing-video-search/quickstarts/sdk/video-search-client-library-csharp.md
+++ b/bing-docs/bing-video-search/quickstarts/sdk/video-search-client-library-csharp.md
@@ -9,12 +9,12 @@ ms.service: bing-search-services
 ms.subservice: bing-video-search
 ms.topic: quickstart
 ms.date: 07/15/2020
-ms.author: scottwhi
+ms.author: v-grvanpelt
 ---
 
 # Quickstart: Use the Bing Video Search .NET client library
 
-Use this quickstart to begin searching for news with the Bing Video Search client library for C#. While Bing Video Search has a REST API compatible with most programming languages, the client library provides an easy way to integrate the service into your applications. The source code for this sample can be found on [GitHub](https://github.com/Azure-Samples/cognitive-services-dotnet-sdk-samples/tree/master/BingSearchv7/BingVideoSearch) with additional annotations, and features.
+Use this quickstart to begin searching for news with the Bing Video Search client library for C#. While Bing Video Search has a REST API compatible with most programming languages, the client library provides an easy way to integrate the service into your applications. The source code for this sample can be found on [GitHub](https://github.com/microsoft/bing-search-sdk-for-net/tree/main/samples/BingSearchSamples/BingVideoSearch) with additional annotations, and features.
 
 ## Prerequisites
 
@@ -85,4 +85,4 @@ Installing the [NuGet Video Search SDK package](https://www.nuget.org/packages/M
 ## See also 
 
 * [What is the Bing Video Search API?](../../overview.md)
-* [Cognitive services .NET SDK samples](https://github.com/Azure-Samples/cognitive-services-dotnet-sdk-samples/tree/master/BingSearchv7)
+* [Bing Video Search .NET SDK samples](https://github.com/microsoft/bing-search-sdk-for-net/blob/main/samples/BingSearchSamples/BingVideoSearch/VideoSearchSamples.cs)

--- a/bing-docs/bing-video-search/quickstarts/sdk/video-search-client-library-java.md
+++ b/bing-docs/bing-video-search/quickstarts/sdk/video-search-client-library-java.md
@@ -8,12 +8,12 @@ manager: ehansen
 ms.service: bing-search-services
 ms.subservice: bing-video-search
 ms.date: 07/15/2020
-ms.author: scottwhi
+ms.author: v-grvanpelt
 ---
 
 # Quickstart: Use the Bing Video Search Java client library
 
-Use this quickstart to begin searching for news with the Bing Video Search client library for Java. While Bing Video Search has a REST API compatible with most programming languages, the client library provides an easy way to integrate the service into your applications. The source code for this sample can be found on [GitHub](https://github.com/Azure-Samples/cognitive-services-java-sdk-samples/tree/master/Search/BingVideoSearch), with additional annotations, and features.
+Use this quickstart to begin searching for news with the Bing Video Search client library for Java. While Bing Video Search has a REST API compatible with most programming languages, the client library provides an easy way to integrate the service into your applications. The source code for this sample can be found on [GitHub](https://github.com/microsoft/bing-search-sdk-for-java/tree/main/samples/sdk/VideoSearchSample), with additional annotations, and features.
 
 ## Prerequisites
 
@@ -160,4 +160,6 @@ Create a new Java project in your favorite IDE or editor, and import the followi
 ## See also 
 
 * [What is the Bing Video Search API?](../../overview.md)
+<!--
 * [Cognitive services .NET SDK samples](https://github.com/Azure-Samples/cognitive-services-dotnet-sdk-samples/tree/master/BingSearchv7)
+-->

--- a/bing-docs/bing-video-search/quickstarts/sdk/video-search-client-library-python.md
+++ b/bing-docs/bing-video-search/quickstarts/sdk/video-search-client-library-python.md
@@ -9,12 +9,12 @@ ms.service: bing-search-services
 ms.subservice: bing-video-search
 ms.topic: quickstart
 ms.date: 07/15/2020
-ms.author: scottwhi
+ms.author: v-grvanpelt
 ---
 
 # Quickstart: Use the Bing Video Search Python client library
 
-Use this quickstart to begin searching for news with the Bing Video Search client library for Python. While Bing Video Search has a REST API compatible with most programming languages, the client library provides an easy way to integrate the service into your applications. The source code for this sample can be found on [GitHub](https://github.com/Azure-Samples/cognitive-services-python-sdk-samples/blob/master/samples/search/video_search_samples.py) with additional annotations and features.
+Use this quickstart to begin searching for news with the Bing Video Search client library for Python. While Bing Video Search has a REST API compatible with most programming languages, the client library provides an easy way to integrate the service into your applications. The source code for this sample can be found on [GitHub](https://github.com/microsoft/bing-search-sdk-for-python/blob/main/samples/sdk/video_search_samples.py) with additional annotations and features.
 
 <!--
 [!INCLUDE [bing-video-search-signup-requirements](../../../../includes/bing-video-search-signup-requirements.md)]
@@ -92,4 +92,6 @@ client = VideoSearchAPI(endpoint, CognitiveServicesCredentials(subscription_key)
 ## See also 
 
 - [What is the Bing Video Search API?](../../overview.md)
+<!--
 - [Cognitive services .NET SDK samples](https://github.com/Azure-Samples/cognitive-services-dotnet-sdk-samples/tree/master/BingSearchv7)
+-->

--- a/bing-docs/bing-video-search/samples.md
+++ b/bing-docs/bing-video-search/samples.md
@@ -9,7 +9,7 @@ ms.service: bing-search-services
 ms.subservice: bing-video-search
 ms.topic: sample
 ms.date: 07/15/2020
-ms.author: scottwhi
+ms.author: v-grvanpelt
 ---
 
 # Bing Video Search API samples
@@ -35,10 +35,10 @@ Here's a list of SDK samples by language. The list is subject to change. For the
 
 |Language|Sample
 |-|-
-|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Video Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs)
-|[Java](https://github.com/Azure-Samples/cognitive-services-java-sdk-samples)|[Bing Video Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java)
+|[C#](https://github.com/microsoft/bing-search-sdk-for-net/tree/main/samples/BingSearchSamples/BingVideoSearch)|[Bing Video Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs)
+|[Java](https://github.com/microsoft/bing-search-sdk-for-java/tree/main/samples/sdk/VideoSearchSample)|[Bing Video Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java)
 |[Node.js](https://github.com/Azure-Samples/cognitive-services-node-sdk-samples)|[Bing Video Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js)
-|[Python](https://github.com/Azure-Samples/cognitive-services-python-sdk-samples)|[Bing Video Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py)
+|[Python](https://github.com/microsoft/bing-search-sdk-for-python/blob/main/samples/sdk/video_search_samples.py)|[Bing Video Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py)
 
 
 ## Next steps


### PR DESCRIPTION
Update SDK Samples/Quick Start links for the Bing Video Search API and remove references to cognitive services