### PR TITLE
Bing Visual Search: Update samples/QS links to latest repo/library

### DIFF
--- a/bing-docs/bing-visual-search/quickstarts/sdk/visual-search-client-library-csharp.md
+++ b/bing-docs/bing-visual-search/quickstarts/sdk/visual-search-client-library-csharp.md
@@ -9,14 +9,16 @@ ms.service: bing-search-services
 ms.subservice: bing-visual-search
 ms.topic: quickstart
 ms.date: 07/15/2020
-ms.author: scottwhi
+ms.author: v-grvanpelt
 ---
 
 # Quickstart: Use the Bing Visual Search .NET client library
 
-Use this quickstart to begin getting image insights from the Bing Visual Search service, using the C# client library. While Bing Visual Search has a REST API compatible with most programming languages, the client library provides an easy way to integrate the service into your applications. The source code for this sample can be found on [GitHub](https://github.com/Azure-Samples/cognitive-services-dotnet-sdk-samples/tree/master/BingSearchv7/BingVisualSearch).
+Use this quickstart to begin getting image insights from the Bing Visual Search service, using the C# client library. While Bing Visual Search has a REST API compatible with most programming languages, the client library provides an easy way to integrate the service into your applications. The source code for this sample can be found on [GitHub](https://github.com/microsoft/bing-search-sdk-for-net/tree/main/samples/BingSearchSamples/BingVisualSearch).
 
+<!--
 [Reference documentation](/dotnet/api/overview/azure/cognitiveservices/bing-visual-search-readme) | [Library source code](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/cognitiveservices/Search.BingVisualSearch) | [Package (NuGet)](https://www.nuget.org/packages/Microsoft.Azure.CognitiveServices.Search.VisualSearch/) | [Samples](https://github.com/Azure-Samples/cognitive-services-dotnet-sdk-samples/)
+-->
 
 ## Prerequisites
 

--- a/bing-docs/bing-visual-search/quickstarts/sdk/visual-search-client-library-java.md
+++ b/bing-docs/bing-visual-search/quickstarts/sdk/visual-search-client-library-java.md
@@ -9,19 +9,21 @@ ms.service: bing-search-services
 ms.subservice: bing-visual-search
 ms.topic: quickstart
 ms.date: 07/15/2020
-ms.author: scottwhi
+ms.author: v-grvanpelt
 ---
 
 # Quickstart: Use the Bing Visual Search Java client library
 
-Use this quickstart to begin getting image insights from the Bing Visual Search service, using the Java client library. While Bing Visual Search has a REST API compatible with most programming languages, the client library provides an easy way to integrate the service into your applications. The source code for this quickstart can be found on [GitHub](https://github.com/Azure-Samples/cognitive-services-java-sdk-samples/tree/master/Search/BingVisualSearch).
+Use this quickstart to begin getting image insights from the Bing Visual Search service, using the Java client library. While Bing Visual Search has a REST API compatible with most programming languages, the client library provides an easy way to integrate the service into your applications. The source code for this quickstart can be found on [GitHub](https://github.com/microsoft/bing-search-sdk-for-java/tree/main/samples/sdk/VisualSearchSample).
 
 Use the Bing Visual Search client library for Java to:
 
 * Upload an image to send a visual search request.
 * Get the image insight token and visual search tags.
 
+<!--
 [Reference documentation](/java/api/overview/azure/cognitiveservices/client/bingvisualsearch?view=azure-java-stable&preserve-view=true) | [Library source code](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/cognitiveservices/Search.BingVisualSearch) | [Artifact (Maven)](https://search.maven.org/artifact/com.microsoft.azure.cognitiveservices/azure-cognitiveservices-visualsearch/) | [Samples](https://github.com/Azure-Samples/cognitive-services-java-sdk-samples)
+-->
 
 ## Prerequisites
 

--- a/bing-docs/bing-visual-search/quickstarts/sdk/visual-search-client-library-python.md
+++ b/bing-docs/bing-visual-search/quickstarts/sdk/visual-search-client-library-python.md
@@ -9,14 +9,16 @@ ms.service: bing-search-services
 ms.subservice: bing-visual-search
 ms.topic: quickstart
 ms.date: 07/15/2020
-ms.author: scottwhi
+ms.author: v-grvanpelt
 ---
 
 # Quickstart: Use the Bing Visual Search Python client library
 
-Use this quickstart to begin getting image insights from the Bing Visual Search service, using the Python client library. While Bing Visual Search has a REST API compatible with most programming languages, the client library provides an easy way to integrate the service into your applications. The source code for this sample can be found on [GitHub](https://github.com/Azure-Samples/cognitive-services-python-sdk-samples/blob/master/samples/search/visual_search_samples.py).
+Use this quickstart to begin getting image insights from the Bing Visual Search service, using the Python client library. While Bing Visual Search has a REST API compatible with most programming languages, the client library provides an easy way to integrate the service into your applications. The source code for this sample can be found on [GitHub](https://github.com/microsoft/bing-search-sdk-for-python/tree/main/samples/sdk).
 
+<!--
 [Reference documentation](/python/api/overview/azure/cognitiveservices/visualsearch?view=azure-python&preserve-view=true) | [Library source code](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/cognitiveservices/azure-cognitiveservices-search-visualsearch) | [Package (PyPi)](https://pypi.org/project/azure-cognitiveservices-search-visualsearch/) | [Samples](https://github.com/Azure-Samples/cognitive-services-python-sdk-samples/)
+-->
 
 ## Prerequisites
 

--- a/bing-docs/bing-visual-search/samples.md
+++ b/bing-docs/bing-visual-search/samples.md
@@ -9,7 +9,7 @@ ms.service: bing-search-services
 ms.subservice: bing-visual-search
 ms.topic: sample
 ms.date: 07/15/2020
-ms.author: scottwhi
+ms.author: v-grvanpelt
 ---
 
 # Bing Visual Search API samples
@@ -34,10 +34,10 @@ Here's a list of SDK samples by language. The list is subject to change. For the
 
 |Language|Sample
 |-|-
-|[C#](https://github.com/microsoft/bing-search-dotnet-samples/tree/main/rest)|[Bing Visual Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs)
-|[Java](https://github.com/Azure-Samples/cognitive-services-java-sdk-samples)|[Bing Visual Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java)
+|[C#](https://github.com/microsoft/bing-search-sdk-for-net/tree/main/samples/BingSearchSamples/BingVisualSearch)|[Bing Visual Search](https://github.com/microsoft/bing-search-dotnet-samples/blob/main/rest/BingWebSearchV7.cs)
+|[Java](https://github.com/microsoft/bing-search-sdk-for-java/blob/main/samples/sdk/VisualSearchSample/BingVisualSearchSample.java)|[Bing Visual Search](https://github.com/microsoft/bing-search-java-samples/blob/main/rest/BingWebSearchV7.java)
 |[Node.js](https://github.com/Azure-Samples/cognitive-services-node-sdk-samples)|[Bing Visual Search](https://github.com/microsoft/bing-search-nodejs-samples/blob/main/rest/BingWebSearchV7.js)
-|[Python](https://github.com/Azure-Samples/cognitive-services-python-sdk-samples)|[Bing Visual Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py)</a>
+|[Python](https://github.com/microsoft/bing-search-sdk-for-python/blob/main/samples/sdk/visual_search_samples.py)|[Bing Visual Search](https://github.com/microsoft/bing-search-python-samples/blob/main/rest/BingWebSearchV7.py)</a>
 
 
 ## Next steps


### PR DESCRIPTION
Update SDK Samples/Quick Start links for the Bing Visual Search API and remove references to cognitive services
