### PR TITLE
docs: decommission docs for search APIs

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -7,7 +7,7 @@
       "locale": "en-us",
       "monikers": [],
       "moniker_ranges": [],
-      "open_to_public_contributors": true,
+      "open_to_public_contributors": false,
       "type_mapping": {
         "Conceptual": "Content"
       },

--- a/bing-docs/bing-autosuggest/reference/error-codes.md
+++ b/bing-docs/bing-autosuggest/reference/error-codes.md
@@ -4,10 +4,11 @@ titleSuffix: Bing Services
 description: Provides the list of HTTP status codes and service error codes that Bing Autosuggest may return.
 author: alekhyasasi
 manager: ehansen
+ms.author: dutescufilip
 ms.service: bing-search-services
 ms.subservice: bing-autosuggest
 ms.topic: reference
-ms.date: 06/01/2023
+ms.date: 06/08/2025
 ---
 
 # HTTP status codes that Bing Autosuggest API may return

--- a/bing-docs/breadcrumb/toc.yml
+++ b/bing-docs/breadcrumb/toc.yml
@@ -2,30 +2,34 @@
   tocHref: /
   topicHref: /
   items:
-  - name: Bing Autosuggest
-    tocHref: /bing/search-apis/bing-autosuggest/
-    topicHref: /bing/search-apis/bing-autosuggest/overview
-  - name: Bing Custom Search
-    tocHref: /bing/search-apis/bing-custom-search/
-    topicHref: /bing/search-apis/bing-custom-search/overview
-  - name: Bing Entity Search
-    tocHref: /bing/search-apis/bing-entity-search/
-    topicHref: /bing/search-apis/bing-entity-search/overview
-  - name: Bing Image Search
-    tocHref: /bing/search-apis/bing-image-search/
-    topicHref: /bing/search-apis/bing-image-search/overview
-  - name: Bing News Search
-    tocHref: /bing/search-apis/bing-news-search/
-    topicHref: /bing/search-apis/bing-news-search/overview
-  - name: Bing Spell Check
-    tocHref: /bing/search-apis/bing-spell-check/
-    topicHref: /bing/search-apis/bing-spell-check/overview
-  - name: Bing Video Search
-    tocHref: /bing/search-apis/bing-video-search/
-    topicHref: /bing/search-apis/bing-video-search/overview
-  - name: Bing Visual Search
-    tocHref: /bing/search-apis/bing-visual-search/
-    topicHref: /bing/search-apis/bing-visual-search/overview
-  - name: Bing Web Search
-    tocHref: /bing/search-apis/bing-web-search/
-    topicHref: /bing/search-apis/bing-web-search/overview
+    - name: Previous Versions
+      tocHref: /previous-versions/
+      topicHref: /previous-versions/
+      items:
+        - name: Bing Autosuggest
+          tocHref: /previous-versions/bing/search-apis/bing-autosuggest/
+          topicHref: /previous-versions/bing/search-apis/bing-autosuggest/overview
+        - name: Bing Custom Search
+          tocHref: /previous-versions/bing/search-apis/bing-custom-search/
+          topicHref: /previous-versions/bing/search-apis/bing-custom-search/overview
+        - name: Bing Entity Search
+          tocHref: /previous-versions/bing/search-apis/bing-entity-search/
+          topicHref: /previous-versions/bing/search-apis/bing-entity-search/overview
+        - name: Bing Image Search
+          tocHref: /previous-versions/bing/search-apis/bing-image-search/
+          topicHref: /previous-versions/bing/search-apis/bing-image-search/overview
+        - name: Bing News Search
+          tocHref: /previous-versions/bing/search-apis/bing-news-search/
+          topicHref: /previous-versions/bing/search-apis/bing-news-search/overview
+        - name: Bing Spell Check
+          tocHref: /previous-versions/bing/search-apis/bing-spell-check/
+          topicHref: /previous-versions/bing/search-apis/bing-spell-check/overview
+        - name: Bing Video Search
+          tocHref: /previous-versions/bing/search-apis/bing-video-search/
+          topicHref: /previous-versions/bing/search-apis/bing-video-search/overview
+        - name: Bing Visual Search
+          tocHref: /previous-versions/bing/search-apis/bing-visual-search/
+          topicHref: /previous-versions/bing/search-apis/bing-visual-search/overview
+        - name: Bing Web Search
+          tocHref: /previous-versions/bing/search-apis/bing-web-search/
+          topicHref: /previous-versions/bing/search-apis/bing-web-search/overview

--- a/bing-docs/docfx.json
+++ b/bing-docs/docfx.json
@@ -39,9 +39,13 @@
     "overwrite": [],
     "externalReference": [],
     "globalMetadata": {
-      "breadcrumb_path": "/bing/search-apis/breadcrumb/toc.json",
+      "ROBOTS": "NOINDEX,NOFOLLOW",
+      "is_archived": true,
+      "is_retired": true,
+      "learn_archive": "manual",
+      "breadcrumb_path": "/previous-versions/bing/search-apis/breadcrumb/toc.json",
       "extendBreadcrumb": true,
-      "feedback_system": "Standard",
+      "feedback_system": "None",
       "defaultDevLang": "csharp",
       "searchScope": ["Bing Search"],
       "uhfHeaderId": "MSDocsHeader-BingSearch"


### PR DESCRIPTION
Remove the documentation for the Search API as it is being decommissioned.